### PR TITLE
Fixed issue with Buckingham not working with dr arrays, added appropr…

### DIFF
--- a/pylj/forcefields.py
+++ b/pylj/forcefields.py
@@ -100,18 +100,13 @@ def buckingham(dr, constants, force=False):
     float: array_like
         The potential energy or force between the particles.
     """
-    if not isinstance(dr, np.ndarray):
-        if isinstance(dr, list):
-            dr = np.array(dr, dtype='float')
-        elif isinstance(dr, float):
-            dr = np.array([dr], dtype='float')
-
     if force:
         return constants[0] * constants[1] * np.exp(
-            -constants[1] * dr) - 6 * constants[2] / np.power(dr, 7)
+            - np.multiply(constants[1], dr)) - 6 * constants[2] / np.power(
+            dr, 7)
     else:
         return constants[0] * np.exp(
-            -constants[1] * dr) - constants[2] / np.power(dr, 6)
+            - np.multiply(constants[1], dr)) - constants[2] / np.power(dr, 6)
 
 
 def square_well(dr, constants, max_val=np.inf, force=False):

--- a/pylj/forcefields.py
+++ b/pylj/forcefields.py
@@ -100,6 +100,11 @@ def buckingham(dr, constants, force=False):
     float: array_like
         The potential energy or force between the particles.
     """
+    if not isinstance(dr, np.ndarray):
+        if isinstance(dr, list):
+            dr = np.array(dr, dtype='float')
+        elif isinstance(dr, float):
+            dr = np.array([dr], dtype='float')
 
     if force:
         return constants[0] * constants[1] * np.exp(

--- a/pylj/tests/test_forcefields.py
+++ b/pylj/tests/test_forcefields.py
@@ -55,10 +55,21 @@ class TestForcefields(unittest.TestCase):
     def test_buckingham_energy(self):
         a = forcefields.buckingham(2.0, [1.0, 1.0, 1.0])
         assert_almost_equal(a, 0.1197103832)
+        b = forcefields.buckingham([2.0], [1.0, 1.0, 1.0])
+        assert_almost_equal(b, 0.1197103832)
+        c = forcefields.buckingham([2.0, 4.0], [1.0, 1.0, 1.0])
+        assert_almost_equal(c, [0.1197103832, 0.0180715])
+        d = forcefields.buckingham([2.0, 4.0, 5.0], [0.01, 0.01, 0.01])
+        assert_almost_equal(d, [0.0096457, 0.0096055, 0.0095117])
 
     def test_buckingham_force(self):
         a = forcefields.buckingham(2.0, [1.0, 1.0, 1.0], force=True)
         assert_almost_equal(a, 0.08846028324)
+        b = forcefields.buckingham([2.0], [1.0, 1.0, 1.0], force=True)
+        assert_almost_equal(b, 0.08846028324)
+        c = forcefields.buckingham(
+            [2.0, 1.0, 4.0], [1.5, 0.1, 2.0], force=True)
+        assert_almost_equal(c, [0.0290596, -11.8642744, 0.0998156])
 
     def test_square_well_energy(self):
         a = forcefields.square_well(2.0, [1.0, 1.5, 2.0])


### PR DESCRIPTION
For #46 

Buckingham forcefield was raising a TypeError when dr was an array. Error was in the np.exp() term which was only used in the Buckingham function but not the other forcefields:
```
np.exp(-constants[1] * dr)
```

When type(dr) == float, the term inside was fine, but multiplication of a non-int and a float i.e ```2.0 * [2.0] ```isn't allowed in python. I fixed this by converting dr to a numpy array by default. Numpy allows this multiplication in their arrays i.e ```2.0 * np.array([2.0])``` returns 4.0. The function should now be able to handle both floats and arrays (lists and numpy arrays) fine.