### PR TITLE
Update RDF calculation sample.py

### DIFF
--- a/pylj/sample.py
+++ b/pylj/sample.py
@@ -639,11 +639,10 @@ def update_rdfview(ax, system, average_rdf, r):  # pragma: no cover
         system.distances, bins=np.linspace(0, system.box_length / 2 + 0.5e-10, 100)
     )
     gr = hist / (
-        system.number_of_particles
+        len(system.distances)/(system.number_of_particles - 1)
         * (system.number_of_particles / system.box_length ** 2)
-        * np.pi
-        * (bin_edges[:-1] + 0.5e-10 / 2.0)
-        * 0.5
+        * 2 * np.pi
+        * (bin_edges[:-1] + 0.5e-10 / 2.0) * (bin_edges[1]-bin_edges[0])
     )
     average_rdf.append(gr)
     x = bin_edges[:-1] + 0.5e-10 / 2


### PR DESCRIPTION
Fixed RDF calculation: the results were giving the wrong order of magnitude and the units of the equation were not correct. 

Added the lacking "2dr" for 2D-Simulations.

Note: "len(system.distances)/(system.number_of_particles - 1)" is the same as "system.number_of_particles*0.5" but it was not clear to me where that came from.
