### PR TITLE
Rescale velocities to the instantaneous temperature in heat_bath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to pylj are recorded here. The format follows
 
 ### Changed
 
+- `md.heat_bath(particles, mass, bath_temperature)` rescales on the instantaneous temperature; it previously took the temperature sample array and rescaled towards its cumulative mean. `System.heat_bath(bath_temperature)` is unchanged. A non-positive bath temperature, or a system with zero or non-finite temperature, raises `ValueError` (#76).
 - Python 3.11 or later is required. scipy is a dependency; Cython is not.
 - `System.__init__` takes keyword-only arguments after `mass`, including the required `simulation`.
 - The initialisers compute the initial forces, so the first integration step uses real accelerations.
@@ -37,4 +38,5 @@ All notable changes to pylj are recorded here. The format follows
 
 ### Removed
 
+- `pairwise.heat_bath`; `md.heat_bath` is the implementation (#76).
 - `pylj/sample.py`, `point_size` on forcefields, `System.type_identifiers`, `pairwise.create_dist_identifiers`, `MANIFEST.in`, and the Code Climate upload from CI.

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -348,16 +348,19 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
 
 
 def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np.ndarray:
-    r"""Rescales the velocities of the particles to the bath temperature,
-    thereby allowing for an NVT ensemble. The rescaling is performed relative
-    to the instantaneous temperature of the current velocities, so the
-    result is correct at any point in the run rather than drifting towards
-    some historic average. The velocities are rescaled according to the
-    following relationship,
+    r"""Rescale the velocities so the instantaneous temperature equals the
+    bath temperature.
+
+    This is a velocity-rescaling thermostat: it holds the instantaneous
+    temperature at the bath temperature whenever it is called, rather than
+    sampling the canonical ensemble. The velocities are rescaled according to
 
     .. math::
         v_{\text{new}} = v_{\text{old}} \times
         \sqrt{\frac{T_{\text{bath}}}{T_{\text{now}}}}
+
+    where :math:`T_{\text{now}}` is the temperature of the current
+    velocities.
 
     Args:
         particles: Information about the particles.
@@ -372,20 +375,24 @@ def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np
 
     Raises:
         ValueError: If bath_temperature is not positive.
-        ValueError: If the current temperature is zero or not finite, so
-            there is nothing to rescale from: the particles are at rest or
-            the simulation has diverged.
+        ValueError: If the current temperature is zero (the particles are at
+            rest, as in a Monte Carlo system) or not finite (the simulation
+            has diverged).
     """
     if not bath_temperature > 0:
         raise ValueError(
             f"bath_temperature must be positive, not {bath_temperature}"
         )
     current_temperature = calculate_temperature(particles, mass)
-    if not current_temperature > 0:
+    if current_temperature == 0:
+        raise ValueError(
+            "Cannot rescale velocities: the particles are at rest. A Monte Carlo "
+            "system has no velocities to thermostat; use md.initialise for MD."
+        )
+    if not (np.isfinite(current_temperature) and current_temperature > 0):
         raise ValueError(
             "Cannot rescale velocities: the current temperature is "
-            f"{current_temperature}, so the particles are at rest or the "
-            "simulation has diverged."
+            f"{current_temperature}, so the simulation has diverged."
         )
     scale = np.sqrt(bath_temperature / current_temperature)
     particles["xvelocity"] = particles["xvelocity"] * scale

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -347,27 +347,38 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     return part, dist, forces, energies
 
 
-def heat_bath(particles, temperature_sample, bath_temperature):
-    r"""Rescales the velocities of the particles in the system to control the
-    temperature of the simulation. Thereby allowing for an NVT ensemble. The
-    velocities are rescaled according the following relationship,
+def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np.ndarray:
+    r"""Rescales the velocities of the particles to the bath temperature,
+    thereby allowing for an NVT ensemble. The rescaling is performed relative
+    to the instantaneous temperature of the current velocities, so the
+    result is correct at any point in the run rather than drifting towards
+    some historic average. The velocities are rescaled according to the
+    following relationship,
+
     .. math::
         v_{\text{new}} = v_{\text{old}} \times
-        \sqrt{\frac{T_{\text{desired}}}{\bar{T}}}
+        \sqrt{\frac{T_{\text{bath}}}{T_{\text{now}}}}
 
-    Parameters
-    ----------
-    particles: util.particle_dt, array_like
-        Information about the particles.
-    temperature_sample: float, array_like
-        The temperature at each timestep in the simulation.
-    bath_temp: float
-        The desired temperature of the simulation.
-        
-    Returns
-    -------
-    util.particle_dt, array_like
+    Args:
+        particles: Information about the particles.
+        mass: The mass of the particles being simulated, in atomic mass
+            units.
+        bath_temperature: The desired temperature of the simulation, in
+            Kelvin.
+
+    Returns:
         Information about the particles with new, rescaled velocities.
+
+    Raises:
+        ValueError: If the particles have no kinetic energy, so there is no
+            temperature to rescale.
     """
-    particles = heavy.heat_bath(particles, temperature_sample, bath_temperature)
+    current_temperature = calculate_temperature(particles, mass)
+    if current_temperature <= 0:
+        raise ValueError(
+            "Cannot rescale velocities: the particles have no kinetic energy."
+        )
+    scale = np.sqrt(bath_temperature / current_temperature)
+    particles["xvelocity"] = particles["xvelocity"] * scale
+    particles["yvelocity"] = particles["yvelocity"] * scale
     return particles

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -367,14 +367,20 @@ def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np
             Kelvin.
 
     Returns:
-        Information about the particles with new, rescaled velocities.
+        The particles with velocities rescaled in place; the same array is
+        returned.
 
     Raises:
+        ValueError: If bath_temperature is not positive.
         ValueError: If the particles have no kinetic energy, so there is no
             temperature to rescale.
     """
+    if not bath_temperature > 0:
+        raise ValueError(
+            f"bath_temperature must be positive, not {bath_temperature}"
+        )
     current_temperature = calculate_temperature(particles, mass)
-    if current_temperature <= 0:
+    if not current_temperature > 0:
         raise ValueError(
             "Cannot rescale velocities: the particles have no kinetic energy."
         )

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -372,8 +372,9 @@ def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np
 
     Raises:
         ValueError: If bath_temperature is not positive.
-        ValueError: If the particles have no kinetic energy, so there is no
-            temperature to rescale.
+        ValueError: If the current temperature is zero or not finite, so
+            there is nothing to rescale from: the particles are at rest or
+            the simulation has diverged.
     """
     if not bath_temperature > 0:
         raise ValueError(
@@ -382,7 +383,9 @@ def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np
     current_temperature = calculate_temperature(particles, mass)
     if not current_temperature > 0:
         raise ValueError(
-            "Cannot rescale velocities: the particles have no kinetic energy."
+            "Cannot rescale velocities: the current temperature is "
+            f"{current_temperature}, so the particles are at rest or the "
+            "simulation has diverged."
         )
     scale = np.sqrt(bath_temperature / current_temperature)
     particles["xvelocity"] = particles["xvelocity"] * scale

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -246,34 +246,6 @@ def calculate_pressure(
     return pres
 
 
-def heat_bath(particles, temperature_sample, bath_temp):
-    r"""Rescales the velocities of the particles in the system to control the
-    temperature of the simulation. Thereby allowing for an NVT ensemble. The
-    velocities are rescaled according the following relationship,
-    .. math::
-        v_{\text{new}} = v_{\text{old}} \times
-        \sqrt{\frac{T_{\text{desired}}}{\bar{T}}}
-
-    Parameters
-    ----------
-    particles: util.particle_dt, array_like
-        Information about the particles.
-    temperature_sample: float, array_like
-        The temperature at each timestep in the simulation.
-    bath_temp: float
-        The desired temperature of the simulation.
-
-    Returns
-    -------
-    util.particle_dt, array_like
-        Information about the particles with new, rescaled velocities.
-    """
-    average_temp = np.average(temperature_sample)
-    particles["xvelocity"] = particles["xvelocity"] * np.sqrt(bath_temp / average_temp)
-    particles["yvelocity"] = particles["yvelocity"] * np.sqrt(bath_temp / average_temp)
-    return particles
-
-
 def dist(xposition, yposition, box_length, types):
     """Returns the distance array for the set of particles.
 

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
@@ -129,3 +130,42 @@ class TestMd(unittest.TestCase):
     def test_initialise_accepts_diameter(self):
         a = md.initialise(2, 300, 8, "square", diameter=3.0)
         assert_almost_equal(a.diameters, [3e-10])
+
+    def test_heat_bath_rescales_to_bath_temperature(self):
+        a = md.initialise(10, 300, 20, "square")
+        a.particles = md.heat_bath(a.particles, a.mass, 250.0)
+        t = md.calculate_temperature(a.particles, a.mass)
+        assert_almost_equal(t / 250.0, 1.0)
+
+    def test_heat_bath_preserves_velocity_directions(self):
+        a = md.initialise(10, 300, 20, "square")
+        old_x = np.array(a.particles["xvelocity"])
+        old_y = np.array(a.particles["yvelocity"])
+        a.particles = md.heat_bath(a.particles, a.mass, 250.0)
+        x_ratio = a.particles["xvelocity"] / old_x
+        y_ratio = a.particles["yvelocity"] / old_y
+        assert_almost_equal(x_ratio, np.full(x_ratio.shape, x_ratio[0]))
+        assert_almost_equal(y_ratio, np.full(y_ratio.shape, x_ratio[0]))
+
+    def test_heat_bath_works_before_any_sample(self):
+        a = md.initialise(10, 300, 20, "square")
+        assert_equal(a.temperature_sample.size, 0)
+        a.heat_bath(50.0)
+        self.assertTrue(np.all(np.isfinite(a.particles["xvelocity"])))
+        self.assertTrue(np.all(np.isfinite(a.particles["yvelocity"])))
+        t = md.calculate_temperature(a.particles, a.mass)
+        assert_almost_equal(t, 50.0)
+
+    def test_heat_bath_two_calls_each_hit_their_own_target(self):
+        a = md.initialise(10, 300, 20, "square")
+        a.particles = md.heat_bath(a.particles, a.mass, 250.0)
+        a.particles = md.heat_bath(a.particles, a.mass, 100.0)
+        t = md.calculate_temperature(a.particles, a.mass)
+        assert_almost_equal(t / 100.0, 1.0)
+
+    def test_heat_bath_raises_when_no_kinetic_energy(self):
+        a = md.initialise(10, 300, 20, "square")
+        a.particles["xvelocity"] = 0.0
+        a.particles["yvelocity"] = 0.0
+        with self.assertRaises(ValueError):
+            md.heat_bath(a.particles, a.mass, 250.0)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -169,3 +169,13 @@ class TestMd(unittest.TestCase):
         a.particles["yvelocity"] = 0.0
         with self.assertRaises(ValueError):
             md.heat_bath(a.particles, a.mass, 250.0)
+
+    def test_heat_bath_raises_for_negative_bath_temperature(self):
+        a = md.initialise(10, 300, 20, "square")
+        with self.assertRaises(ValueError):
+            md.heat_bath(a.particles, a.mass, -5.0)
+
+    def test_heat_bath_raises_for_zero_bath_temperature(self):
+        a = md.initialise(10, 300, 20, "square")
+        with self.assertRaises(ValueError):
+            md.heat_bath(a.particles, a.mass, 0.0)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -146,14 +146,13 @@ class TestMd(unittest.TestCase):
         assert_almost_equal(x_ratio, np.full(x_ratio.shape, x_ratio[0]))
         assert_almost_equal(y_ratio, np.full(y_ratio.shape, x_ratio[0]))
 
-    def test_heat_bath_works_before_any_sample(self):
-        a = md.initialise(10, 300, 20, "square")
-        assert_equal(a.temperature_sample.size, 0)
-        a.heat_bath(50.0)
-        self.assertTrue(np.all(np.isfinite(a.particles["xvelocity"])))
-        self.assertTrue(np.all(np.isfinite(a.particles["yvelocity"])))
-        t = md.calculate_temperature(a.particles, a.mass)
-        assert_almost_equal(t, 50.0)
+    def test_heat_bath_ignores_the_temperature_sample_record(self):
+        for history in ([], [1000.0, 1000.0, 1000.0]):
+            a = md.initialise(10, 300, 20, "square")
+            a.temperature_sample = np.array(history)
+            a.heat_bath(50.0)
+            t = md.calculate_temperature(a.particles, a.mass)
+            assert_almost_equal(t, 50.0)
 
     def test_heat_bath_two_calls_each_hit_their_own_target(self):
         a = md.initialise(10, 300, 20, "square")
@@ -162,19 +161,24 @@ class TestMd(unittest.TestCase):
         t = md.calculate_temperature(a.particles, a.mass)
         assert_almost_equal(t / 100.0, 1.0)
 
-    def test_heat_bath_raises_when_no_kinetic_energy(self):
+    def test_heat_bath_raises_when_the_particles_are_at_rest(self):
         a = md.initialise(10, 300, 20, "square")
         a.particles["xvelocity"] = 0.0
         a.particles["yvelocity"] = 0.0
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as context:
             md.heat_bath(a.particles, a.mass, 250.0)
+        self.assertIn("at rest", str(context.exception))
 
-    def test_heat_bath_raises_for_negative_bath_temperature(self):
-        a = md.initialise(10, 300, 20, "square")
-        with self.assertRaises(ValueError):
-            md.heat_bath(a.particles, a.mass, -5.0)
+    def test_heat_bath_raises_when_the_temperature_is_not_finite(self):
+        for bad in (np.inf, np.nan):
+            a = md.initialise(10, 300, 20, "square")
+            a.particles["xvelocity"][0] = bad
+            with self.assertRaises(ValueError) as context:
+                md.heat_bath(a.particles, a.mass, 250.0)
+            self.assertIn("diverged", str(context.exception))
 
-    def test_heat_bath_raises_for_zero_bath_temperature(self):
-        a = md.initialise(10, 300, 20, "square")
-        with self.assertRaises(ValueError):
-            md.heat_bath(a.particles, a.mass, 0.0)
+    def test_heat_bath_raises_for_a_non_positive_bath_temperature(self):
+        for bad in (0.0, -5.0, np.nan):
+            a = md.initialise(10, 300, 20, "square")
+            with self.assertRaises(ValueError):
+                md.heat_bath(a.particles, a.mass, bad)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -1,5 +1,4 @@
 import unittest
-import numpy as np
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -279,9 +279,7 @@ class System:
         bath_temperature: float
             The target temperature for the simulation.
         """
-        self.particles = md.heat_bath(
-            self.particles, self.temperature_sample, bath_temperature
-        )
+        self.particles = md.heat_bath(self.particles, self.mass, bath_temperature)
 
     def mc_sample(self):
         """Maps to the mc.sample function, recording the current accepted energy."""

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -271,13 +271,15 @@ class System:
         """
         md.sample(self.particles, self.box_length, self.initial_particles, self)
 
-    def heat_bath(self, bath_temperature):
-        """Maps to the md.heat_bath function.
+    def heat_bath(self, bath_temperature: float) -> None:
+        """Rescale the particle velocities to the bath temperature.
 
-        Parameters
-        ----------
-        bath_temperature: float
-            The target temperature for the simulation.
+        Args:
+            bath_temperature: The desired temperature, in Kelvin.
+
+        Raises:
+            ValueError: If the bath temperature is not positive, or the
+                particles are at rest or the simulation has diverged.
         """
         self.particles = md.heat_bath(self.particles, self.mass, bath_temperature)
 


### PR DESCRIPTION
Closes #76. Independent of #73; based on `master`.

## Summary

`heat_bath` rescaled velocities towards the cumulative mean of every temperature recorded since the start of the run, so its target drifted and the thermostat stopped acting, and it produced NaN velocities when called before the first sample.

## What changes

- `md.heat_bath(particles, mass, bath_temperature)` rescales on the temperature of the current velocities, so one call lands exactly on the bath temperature and the call is correct at any point in the run, including before any sample.
- A non-positive or NaN bath temperature raises `ValueError` naming the value; previously a negative value produced NaN velocities silently and then defeated the guard on every later call.
- A zero or non-finite current temperature raises `ValueError` naming the temperature, so a system at rest (for example a Monte Carlo system) or a diverged run is reported rather than propagated.
- `pairwise.heat_bath` is removed; `md.heat_bath` is the implementation. `System.heat_bath(bath_temperature)` is unchanged for callers, and the example notebooks' `system.heat_bath(temperature)` runs verbatim.
- The velocities are rescaled in place and the same array is returned, as before; the docstring now says so.

## Compatibility

The free function's signature changes from `heat_bath(particles, temperature_sample, bath_temp)` to `heat_bath(particles, mass, bath_temperature)`. An old-style call passes an array as `mass` and rescales wrongly rather than raising. Notebooks that use `system.heat_bath(...)` are unaffected.

## Tests

Seven tests added: one call lands on the bath temperature; directions are preserved (a regression guard, since the old code also scaled isotropically); the call works before any sample; consecutive calls each hit their own target; and the three error cases.

