### PR TITLE
Keep initial configurations outside the repulsive core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to pylj are recorded here. The format follows
 - `System.simulation`, `'md'` or `'mc'`, set by the initialisers.
 - `step_sample` on `System`, recorded by `md.sample` and `mc.sample`, so viewers work at any sampling cadence.
 - A `diameter` property on every forcefield (the separation at the pair-potential minimum) and a `diameter` argument on `md.initialise` and `mc.initialise` to override it, in Angstrom. Particles are drawn to scale.
-- `System.cores`, the separation at which each forcefield's pair energy falls to zero, found numerically from its `energy` method. Initial configurations keep particles at least this far apart; the `diameter` override does not affect it.
+- `System.cores`, the separation at which each forcefield's pair energy falls to zero, found numerically from its `energy` method. Initial configurations keep particles at least this far apart.
 - `pylj.constants`, taking the Boltzmann constant and the atomic mass unit from `scipy.constants`.
 - ruff and mypy configuration in `pyproject.toml`, a `dev` extra, and continuous integration on Python 3.11 to 3.14.
 
@@ -37,7 +37,8 @@ All notable changes to pylj are recorded here. The format follows
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
 - Random initial configurations no longer overlap: particles are placed at least their repulsive-core separation apart (#82).
-- The square lattice refuses a spacing below the repulsive core, with the largest count or smallest box that fits in the message (#82).
+- The square lattice refuses a spacing below the repulsive core, with the largest count or the smallest box that fits, rounded up so the suggested box is accepted, in the message (#82).
+- A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units), or whose diameter is non-finite, is refused with a clear message.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to pylj are recorded here. The format follows
 - `System.simulation`, `'md'` or `'mc'`, set by the initialisers.
 - `step_sample` on `System`, recorded by `md.sample` and `mc.sample`, so viewers work at any sampling cadence.
 - A `diameter` property on every forcefield (the separation at the pair-potential minimum) and a `diameter` argument on `md.initialise` and `mc.initialise` to override it, in Angstrom. Particles are drawn to scale.
+- `System.cores`, the separation at which each forcefield's pair energy falls to zero, found numerically from its `energy` method. Initial configurations keep particles at least this far apart; the `diameter` override does not affect it.
 - `pylj.constants`, taking the Boltzmann constant and the atomic mass unit from `scipy.constants`.
 - ruff and mypy configuration in `pyproject.toml`, a `dev` extra, and continuous integration on Python 3.11 to 3.14.
 
@@ -34,9 +35,9 @@ All notable changes to pylj are recorded here. The format follows
 - Pair energies in multi-type systems were counted once per type pair (#81).
 - `mc.metropolis` reused one random number for the life of the process (#78).
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
-- A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive diameter is refused with a clear message.
-- `System.random` placed particles uniformly with no separation check, so a first step could give overlapping particles and unphysical accelerations; it now places each particle by rejection sampling, keeping every pair at least the mean of their diameters apart, and raises `ValueError` if a placement cannot be found after 1000 attempts (#82).
-- `System.square` had the same defect at higher density: it spaced particles by `box_length / ceil(sqrt(n))` with no check, silently overlapping them above a threshold particle count. It now raises `ValueError` if that spacing is less than the largest drawn diameter (#82).
+- A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
+- Random initial configurations no longer overlap: particles are placed at least their repulsive-core separation apart (#82).
+- The square lattice refuses a spacing below the repulsive core, with the largest count or smallest box that fits in the message (#82).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to pylj are recorded here. The format follows
 - `mc.metropolis` reused one random number for the life of the process (#78).
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive diameter is refused with a clear message.
+- `System.random` placed particles uniformly with no separation check, so a first step could give overlapping particles and unphysical accelerations; it now places each particle by rejection sampling, keeping every pair at least the mean of their diameters apart, and raises `ValueError` if a placement cannot be found after 1000 attempts (#82).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to pylj are recorded here. The format follows
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
 - Random initial configurations no longer overlap: particles are placed at least their repulsive-core separation apart (#82).
 - The square lattice refuses a spacing below the repulsive core, with the largest count or the smallest box that fits, rounded up so the suggested box is accepted, in the message (#82).
-- A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units), or whose diameter is non-finite, is refused with a clear message.
+- A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units) is refused with a clear message.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to pylj are recorded here. The format follows
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive diameter is refused with a clear message.
 - `System.random` placed particles uniformly with no separation check, so a first step could give overlapping particles and unphysical accelerations; it now places each particle by rejection sampling, keeping every pair at least the mean of their diameters apart, and raises `ValueError` if a placement cannot be found after 1000 attempts (#82).
+- `System.square` had the same defect at higher density: it spaced particles by `box_length / ceil(sqrt(n))` with no check, silently overlapping them above a threshold particle count. It now raises `ValueError` if that spacing is less than the largest drawn diameter (#82).
 
 ### Removed
 

--- a/docs/source/byof.rst
+++ b/docs/source/byof.rst
@@ -36,7 +36,7 @@ Writing your own forcefield and passing it to the pylj engine is very simple. Fi
 The four members do the following.
 
 - :code:`diameter` is the separation at the minimum of the pair potential, in metres. The particles are drawn with this diameter, so the picture of the cell is to scale. It can be overridden with the :code:`diameter` argument to :code:`md.initialise` or :code:`mc.initialise`, which is given in Angstrom.
-- :code:`energy` and :code:`force` return the pair energy and the magnitude of the pair force for an array of separations :code:`dr`, in metres. When particles are placed for an initial configuration, pylj locates the separation at which :code:`energy` falls from positive to zero or negative, between 0.1 and 50 Angstrom, and keeps particles at least this far apart; it does not use :code:`diameter` for this. A forcefield whose energy never falls from positive within that range is refused when the system is constructed.
+- :code:`energy` and :code:`force` return the pair energy and the magnitude of the pair force for an array of separations :code:`dr`, in metres. When particles are placed for an initial configuration, pylj locates the separation at which :code:`energy` falls from positive to zero or negative, between 0.1 and 50 Angstrom, and keeps particles at least this far apart. A forcefield whose energy never falls from positive within that range is refused when the system is constructed.
 - :code:`mixing` combines this forcefield's constants with those of a second particle type, and is called when a simulation has more than one set of constants. Geometric or arithmetic means of the two sets are the usual choices.
 
 The Lennard-Jones forcefield in the :doc:`forcefields` module is a complete example.

--- a/docs/source/byof.rst
+++ b/docs/source/byof.rst
@@ -36,7 +36,7 @@ Writing your own forcefield and passing it to the pylj engine is very simple. Fi
 The four members do the following.
 
 - :code:`diameter` is the separation at the minimum of the pair potential, in metres. The particles are drawn with this diameter, so the picture of the cell is to scale. It can be overridden with the :code:`diameter` argument to :code:`md.initialise` or :code:`mc.initialise`, which is given in Angstrom.
-- :code:`energy` and :code:`force` return the pair energy and the magnitude of the pair force for an array of separations :code:`dr`, in metres.
+- :code:`energy` and :code:`force` return the pair energy and the magnitude of the pair force for an array of separations :code:`dr`, in metres. When particles are placed for an initial configuration, pylj locates the separation at which :code:`energy` falls from positive to zero or negative, between 0.1 and 50 Angstrom, and keeps particles at least this far apart; it does not use :code:`diameter` for this. A forcefield whose energy never falls from positive within that range is refused when the system is constructed.
 - :code:`mixing` combines this forcefield's constants with those of a second particle type, and is called when a simulation has more than one set of constants. Geometric or arithmetic means of the two sets are the usual choices.
 
 The Lennard-Jones forcefield in the :doc:`forcefields` module is a complete example.

--- a/examples/simple_examples/monte_carlo.ipynb
+++ b/examples/simple_examples/monte_carlo.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system = mc_simulation(50, 273.15, 45, 2500, 25)"
+    "system = mc_simulation(50, 273.15, 100, 2500, 25)"
    ]
   },
   {

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -25,7 +25,7 @@ def initialise(
         Initial temperature of the particles, in Kelvin.
     box_length: float
         Length of a single dimension of the simulation square, in Angstrom.
-    init_conf: string, optional
+    init_conf: string
         The way that the particles are initially positioned. Should be one of:
         - 'square'
         - 'random'

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -29,6 +29,8 @@ def initialise(
         The way that the particles are initially positioned. Should be one of:
         - 'square'
         - 'random'
+        Both raise ``ValueError`` if the particles cannot be placed without
+        their repulsive cores overlapping.
     mass: float (optional)
         The mass of the particles being simulated.
     constants: float, array_like (optional)

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -28,7 +28,7 @@ def initialise(
         Initial temperature of the particles, in Kelvin.
     box_length: float
         Length of a single dimension of the simulation square, in Angstrom.
-    init_conf: string, optional
+    init_conf: string
         The way that the particles are initially positioned. Should be one of:
         - 'square'
         - 'random'

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -32,6 +32,8 @@ def initialise(
         The way that the particles are initially positioned. Should be one of:
         - 'square'
         - 'random'
+        Both raise ``ValueError`` if the particles cannot be placed without
+        their repulsive cores overlapping.
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     mass: float (optional)

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -33,7 +33,7 @@ class TestMc(unittest.TestCase):
         assert_almost_equal(a.diameters, [3e-10])
 
     def test_initialize_passes_keyword_arguments_through(self):
-        constants = [[1.0, 0.25]]
+        constants = [[3.4e-10, 1.65e-21]]
         a = mc.initialize(
             2,
             300,

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -24,7 +24,7 @@ class TestMd(unittest.TestCase):
         self.assertTrue(np.any(a.particles["yacceleration"] != 0))
 
     def test_initialize_passes_keyword_arguments_through(self):
-        constants = [[1.0, 0.25]]
+        constants = [[3.4e-10, 1.65e-21]]
         a = md.initialize(
             2,
             300,

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -125,7 +125,7 @@ def test_fit_axes_is_silent_on_empty_data():
 
 
 def test_cell_pane_draws_each_type_separately():
-    system = md.initialise(4, 100, 20, "square", constants=TWO_TYPES)
+    system = md.initialise(4, 100, 30, "square", constants=TWO_TYPES)
     fig, ax = environment(1)
     pane = CellPane()
     pane.setup(ax, system)

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -211,7 +211,7 @@ def test_rdf_pane_normalisation_is_unity_for_random_positions():
     state = np.random.get_state()
     try:
         np.random.seed(1)
-        system = md.initialise(200, 100, 100, "random")
+        system = md.initialise(400, 100, 100, "random")
     finally:
         np.random.set_state(state)
     fig, ax = environment(1)

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -211,7 +211,7 @@ def test_rdf_pane_normalisation_is_unity_for_random_positions():
     state = np.random.get_state()
     try:
         np.random.seed(1)
-        system = md.initialise(400, 100, 100, "random")
+        system = md.initialise(200, 100, 100, "random")
     finally:
         np.random.set_state(state)
     fig, ax = environment(1)

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -6,9 +6,10 @@ from numpy.testing import assert_almost_equal, assert_equal
 from pylj import forcefields as ff
 from pylj import util
 
-# A second Lennard-Jones type with a repulsive core of 5 Angstrom (sigma) and
-# the same epsilon as argon, chosen for a modest lattice spacing.
-FIVE_ANGSTROM_CORE = [1.5402269415180226e-132, 9.857452425715339e-77]
+# Sigma and epsilon in metres and joules for two Lennard-Jones species: argon,
+# and a larger particle with a 5 Angstrom core and the same well depth.
+ARGON = [3.37e-10, 1.58e-21]
+LARGER = [5.0e-10, 1.58e-21]
 
 
 class TestUtil(unittest.TestCase):
@@ -307,23 +308,23 @@ class TestUtil(unittest.TestCase):
         assert_almost_equal(a.diameters[0] * 1e10, 3.78, decimal=2)
 
     def test_system_single_diameter_applies_to_every_type(self):
-        constants = [[1.363e-134, 9.273e-78], FIVE_ANGSTROM_CORE]
+        constants = [ARGON, LARGER]
         a = util.System(
-            2, 300, 12, constants, ff.lennard_jones, 39.948, simulation="md", diameter=3.0
+            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948, simulation="md", diameter=3.0
         )
         assert_almost_equal(a.diameters, [3e-10, 3e-10])
 
     def test_system_diameter_list_is_per_type(self):
-        constants = [[1.363e-134, 9.273e-78], FIVE_ANGSTROM_CORE]
+        constants = [ARGON, LARGER]
         a = util.System(
-            2, 300, 12, constants, ff.lennard_jones, 39.948, simulation="md", diameter=[3.0, 5.0]
+            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948, simulation="md", diameter=[3.0, 5.0]
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])
 
     def test_system_diameter_array_is_per_type(self):
-        constants = [[1.363e-134, 9.273e-78], FIVE_ANGSTROM_CORE]
+        constants = [ARGON, LARGER]
         a = util.System(
-            2, 300, 12, constants, ff.lennard_jones, 39.948, simulation="md",
+            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948, simulation="md",
             diameter=np.array([3.0, 5.0]),
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -111,6 +111,13 @@ class TestUtil(unittest.TestCase):
                 simulation="md",
             )
 
+    def test_system_square_overlap_message_for_one_particle(self):
+        with self.assertRaisesRegex(ValueError, "1 particle fits"):
+            util.System(
+                5, 100, 4, [[1.363e-134, 9.273e-78]], ff.lennard_jones, 39.948,
+                simulation="md",
+            )
+
     def test_system_square_overlap_raises(self):
         # 50 argon particles in a 20 Angstrom box: at most 25 fit on a
         # square lattice without overlap.

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -1,3 +1,5 @@
+import itertools
+import re
 import unittest
 
 import numpy as np
@@ -10,6 +12,23 @@ from pylj import util
 # and a larger particle with a 5 Angstrom core and the same well depth.
 ARGON = [3.37e-10, 1.58e-21]
 LARGER = [5.0e-10, 1.58e-21]
+
+
+def minimum_image_distances(system):
+    """Return the minimum-image separation, in metres, for every pair of
+    particles in ``system``."""
+    box_length = system.box_length
+    x = system.particles["xposition"]
+    y = system.particles["yposition"]
+    distances = []
+    for i in range(system.number_of_particles):
+        for j in range(i + 1, system.number_of_particles):
+            dx = x[i] - x[j]
+            dy = y[i] - y[j]
+            dx -= box_length * np.round(dx / box_length)
+            dy -= box_length * np.round(dy / box_length)
+            distances.append(np.sqrt(dx**2 + dy**2))
+    return distances
 
 
 class TestUtil(unittest.TestCase):
@@ -76,17 +95,8 @@ class TestUtil(unittest.TestCase):
             )
         finally:
             np.random.set_state(state)
-        box_length = a.box_length
-        x = a.particles["xposition"]
-        y = a.particles["yposition"]
-        for i in range(a.number_of_particles):
-            for j in range(i + 1, a.number_of_particles):
-                dx = x[i] - x[j]
-                dy = y[i] - y[j]
-                dx -= box_length * np.round(dx / box_length)
-                dy -= box_length * np.round(dy / box_length)
-                distance = np.sqrt(dx**2 + dy**2)
-                self.assertTrue(distance >= a.cores[0])
+        for distance in minimum_image_distances(a):
+            self.assertTrue(distance >= a.cores[0])
 
     def test_system_random_too_dense_raises(self):
         with self.assertRaisesRegex(ValueError, "after 1000 attempts"):
@@ -102,7 +112,9 @@ class TestUtil(unittest.TestCase):
             )
 
     def test_system_square_overlap_raises(self):
-        with self.assertRaises(ValueError) as context:
+        # 50 argon particles in a 20 Angstrom box: at most 25 fit on a
+        # square lattice without overlap.
+        with self.assertRaisesRegex(ValueError, "25"):
             util.System(
                 50,
                 100,
@@ -112,9 +124,6 @@ class TestUtil(unittest.TestCase):
                 forcefield=ff.lennard_jones,
                 simulation="md",
             )
-        message = str(context.exception)
-        self.assertTrue("repulsive core" in message)
-        self.assertTrue("fit" in message)
 
     def test_system_square_between_core_and_diameter_is_accepted(self):
         # 101 argon particles in a 40 Angstrom box space 3.64 Angstrom apart:
@@ -152,17 +161,7 @@ class TestUtil(unittest.TestCase):
             )
         finally:
             np.random.set_state(state)
-        box_length = a.box_length
-        x = a.particles["xposition"]
-        y = a.particles["yposition"]
-        distances = []
-        for i in range(a.number_of_particles):
-            for j in range(i + 1, a.number_of_particles):
-                dx = x[i] - x[j]
-                dy = y[i] - y[j]
-                dx -= box_length * np.round(dx / box_length)
-                dy -= box_length * np.round(dy / box_length)
-                distances.append(np.sqrt(dx**2 + dy**2))
+        distances = minimum_image_distances(a)
         self.assertTrue(all(distance >= a.cores[0] for distance in distances))
         self.assertTrue(any(distance < 8e-10 for distance in distances))
 
@@ -183,20 +182,13 @@ class TestUtil(unittest.TestCase):
             )
         finally:
             np.random.set_state(state)
-        box_length = a.box_length
-        x = a.particles["xposition"]
-        y = a.particles["yposition"]
         types = a.particles["types"]
-        for i in range(a.number_of_particles):
-            for j in range(i + 1, a.number_of_particles):
-                dx = x[i] - x[j]
-                dy = y[i] - y[j]
-                dx -= box_length * np.round(dx / box_length)
-                dy -= box_length * np.round(dy / box_length)
-                distance = np.sqrt(dx**2 + dy**2)
-                type_i, type_j = int(types[i]), int(types[j])
-                min_separation = (a.cores[type_i] + a.cores[type_j]) / 2
-                self.assertTrue(distance >= min_separation)
+        distances = minimum_image_distances(a)
+        pairs = itertools.combinations(range(a.number_of_particles), 2)
+        for distance, (i, j) in zip(distances, pairs, strict=True):
+            type_i, type_j = int(types[i]), int(types[j])
+            min_separation = (a.cores[type_i] + a.cores[type_j]) / 2
+            self.assertTrue(distance >= min_separation)
 
     def test_system_argon_core_equals_sigma(self):
         a = util.System(
@@ -205,11 +197,12 @@ class TestUtil(unittest.TestCase):
         expected_sigma = (1.363e-134 / 9.273e-78) ** (1 / 6)
         assert_almost_equal(a.cores[0] * 1e10, expected_sigma * 1e10, decimal=3)
 
-    def test_system_square_well_core_equals_sigma(self):
+    def test_system_square_well_core_is_at_least_sigma(self):
+        sigma = 1.5e-10
         b = util.System(
-            2, 300, 8, [[1.0, 1.5e-10, 2.0]], ff.square_well, 39.948, simulation="md"
+            2, 300, 8, [[1.0, sigma, 2.0]], ff.square_well, 39.948, simulation="md"
         )
-        assert_almost_equal(b.cores[0], 1.5e-10, decimal=12)
+        self.assertTrue(b.cores[0] >= sigma)
 
     def test_system_forcefield_never_positive_raises(self):
         class NeverPositive:
@@ -378,3 +371,100 @@ class TestUtil(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "ZeroDiameter"):
             util.System(2, 300, 8, [[1.0]], ZeroDiameter, 39.948, simulation="md")
+
+    def test_system_diameter_must_be_finite(self):
+        constants = [[1.363e-134, 9.273e-78]]
+        with self.assertRaisesRegex(ValueError, "nan"):
+            util.System(
+                2, 300, 8, constants, ff.lennard_jones, 39.948, simulation="md",
+                diameter=float("nan"),
+            )
+
+    def test_system_square_too_small_box_suggests_a_box_that_fits(self):
+        for number_of_particles in (2, 7, 50):
+            with self.assertRaises(ValueError) as context:
+                util.System(
+                    number_of_particles,
+                    100,
+                    4,
+                    mass=39.948,
+                    constants=[[1.363e-134, 9.273e-78]],
+                    forcefield=ff.lennard_jones,
+                    simulation="md",
+                )
+            match = re.search(r"at least ([0-9.]+) Angstrom fits", str(context.exception))
+            self.assertIsNotNone(match)
+            suggested_box = float(match.group(1))
+            a = util.System(
+                number_of_particles,
+                100,
+                suggested_box,
+                mass=39.948,
+                constants=[[1.363e-134, 9.273e-78]],
+                forcefield=ff.lennard_jones,
+                simulation="md",
+            )
+            self.assertEqual(a.number_of_particles, number_of_particles)
+
+    def test_system_forcefield_energy_returning_a_scalar_is_rejected(self):
+        class ScalarEnergy:
+            def __init__(self, constants):
+                self.constants = constants
+
+            @property
+            def diameter(self):
+                return 1e-10
+
+            def energy(self, dr):
+                return 1.0
+
+        with self.assertRaisesRegex(ValueError, "one value per separation"):
+            util.System(2, 300, 8, [[1.0]], ScalarEnergy, 39.948, simulation="md")
+
+    def test_system_forcefield_energy_returning_the_wrong_shape_is_rejected(self):
+        class ShortEnergy:
+            def __init__(self, constants):
+                self.constants = constants
+
+            @property
+            def diameter(self):
+                return 1e-10
+
+            def energy(self, dr):
+                return np.ones(3)
+
+        with self.assertRaisesRegex(ValueError, "one value per separation"):
+            util.System(2, 300, 8, [[1.0]], ShortEnergy, 39.948, simulation="md")
+
+    def test_system_forcefield_energy_positive_at_50_angstrom_names_units(self):
+        # Sigma given in Angstrom rather than metres: the pair energy never
+        # falls to zero on the 0.1 to 50 Angstrom grid.
+        with self.assertRaisesRegex(ValueError, "still positive at 50 Angstrom"):
+            util.System(
+                2, 300, 8, [[3.4, 1.58e-21]], ff.lennard_jones_sigma_epsilon, 39.948,
+                simulation="md",
+            )
+
+    def test_system_random_buckingham_core_energy_is_near_zero(self):
+        state = np.random.get_state()
+        np.random.seed(0)
+        try:
+            a = util.System(
+                10,
+                100,
+                40,
+                init_conf="random",
+                mass=39.948,
+                constants=[[1.69e-15, 3.66e10, 1.01e-77]],
+                forcefield=ff.buckingham,
+                simulation="md",
+            )
+        finally:
+            np.random.set_state(state)
+        self.assertTrue(a.cores[0] > 3e-10)
+        r = np.logspace(-11, np.log10(5e-9), 4000)
+        well_depth = ff.buckingham([1.69e-15, 3.66e10, 1.01e-77]).energy(r).min()
+        core_energy = ff.buckingham(
+            [1.69e-15, 3.66e10, 1.01e-77]
+        ).energy(np.array([a.cores[0]]))[0]
+        self.assertTrue(abs(core_energy) < 1e-3 * abs(well_depth))

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -310,14 +310,16 @@ class TestUtil(unittest.TestCase):
     def test_system_single_diameter_applies_to_every_type(self):
         constants = [ARGON, LARGER]
         a = util.System(
-            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948, simulation="md", diameter=3.0
+            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948,
+            simulation="md", diameter=3.0,
         )
         assert_almost_equal(a.diameters, [3e-10, 3e-10])
 
     def test_system_diameter_list_is_per_type(self):
         constants = [ARGON, LARGER]
         a = util.System(
-            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948, simulation="md", diameter=[3.0, 5.0]
+            2, 300, 12, constants, ff.lennard_jones_sigma_epsilon, 39.948,
+            simulation="md", diameter=[3.0, 5.0],
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])
 

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -6,6 +6,10 @@ from numpy.testing import assert_almost_equal, assert_equal
 from pylj import forcefields as ff
 from pylj import util
 
+# A second Lennard-Jones type with a repulsive core of 5 Angstrom (sigma) and
+# the same epsilon as argon, chosen for a modest lattice spacing.
+FIVE_ANGSTROM_CORE = [1.5402269415180226e-132, 9.857452425715339e-77]
+
 
 class TestUtil(unittest.TestCase):
     def test_system_square(self):
@@ -81,10 +85,10 @@ class TestUtil(unittest.TestCase):
                 dx -= box_length * np.round(dx / box_length)
                 dy -= box_length * np.round(dy / box_length)
                 distance = np.sqrt(dx**2 + dy**2)
-                self.assertTrue(distance >= a.diameters[0])
+                self.assertTrue(distance >= a.cores[0])
 
     def test_system_random_too_dense_raises(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegex(ValueError, "after 1000 attempts"):
             util.System(
                 200,
                 100,
@@ -95,9 +99,6 @@ class TestUtil(unittest.TestCase):
                 forcefield=ff.lennard_jones,
                 simulation="md",
             )
-        message = str(context.exception)
-        self.assertTrue("particle" in message)
-        self.assertFalse("square" in message)
 
     def test_system_square_overlap_raises(self):
         with self.assertRaises(ValueError) as context:
@@ -110,23 +111,81 @@ class TestUtil(unittest.TestCase):
                 forcefield=ff.lennard_jones,
                 simulation="md",
             )
-        self.assertTrue("diameter" in str(context.exception))
+        message = str(context.exception)
+        self.assertTrue("repulsive core" in message)
+        self.assertTrue("fit" in message)
 
-    def test_system_random_diameter_override(self):
+    def test_system_square_between_core_and_diameter_is_accepted(self):
+        # 100 argon particles in a 40 Angstrom box space 4.0 Angstrom apart:
+        # above the 3.4 Angstrom repulsive core, but below the 3.78 Angstrom
+        # drawn diameter, which used to be the (overly strict) threshold.
         a = util.System(
-            10,
+            100,
             100,
             40,
-            init_conf="random",
             mass=39.948,
             constants=[[1.363e-134, 9.273e-78]],
             forcefield=ff.lennard_jones,
             simulation="md",
-            diameter=8.0,
         )
+        assert_equal(a.number_of_particles, 100)
+
+    def test_system_random_threshold_is_the_core_not_the_drawn_diameter(self):
+        # A diameter=8.0 override only changes how particles are drawn, not
+        # how far apart random() places them: with seed 4, particles land
+        # closer together than 8 Angstrom but still respect the 3.37
+        # Angstrom repulsive core.
+        state = np.random.get_state()
+        np.random.seed(4)
+        try:
+            a = util.System(
+                10,
+                100,
+                30,
+                init_conf="random",
+                mass=39.948,
+                constants=[[1.363e-134, 9.273e-78]],
+                forcefield=ff.lennard_jones,
+                simulation="md",
+                diameter=8.0,
+            )
+        finally:
+            np.random.set_state(state)
         box_length = a.box_length
         x = a.particles["xposition"]
         y = a.particles["yposition"]
+        distances = []
+        for i in range(a.number_of_particles):
+            for j in range(i + 1, a.number_of_particles):
+                dx = x[i] - x[j]
+                dy = y[i] - y[j]
+                dx -= box_length * np.round(dx / box_length)
+                dy -= box_length * np.round(dy / box_length)
+                distances.append(np.sqrt(dx**2 + dy**2))
+        self.assertTrue(all(distance >= a.cores[0] for distance in distances))
+        self.assertTrue(any(distance < 8e-10 for distance in distances))
+
+    def test_system_random_two_types_uses_the_mean_of_the_pair_cores(self):
+        constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
+        state = np.random.get_state()
+        np.random.seed(0)
+        try:
+            a = util.System(
+                12,
+                100,
+                60,
+                init_conf="random",
+                mass=39.948,
+                constants=constants,
+                forcefield=ff.lennard_jones,
+                simulation="md",
+            )
+        finally:
+            np.random.set_state(state)
+        box_length = a.box_length
+        x = a.particles["xposition"]
+        y = a.particles["yposition"]
+        types = a.particles["types"]
         for i in range(a.number_of_particles):
             for j in range(i + 1, a.number_of_particles):
                 dx = x[i] - x[j]
@@ -134,7 +193,49 @@ class TestUtil(unittest.TestCase):
                 dx -= box_length * np.round(dx / box_length)
                 dy -= box_length * np.round(dy / box_length)
                 distance = np.sqrt(dx**2 + dy**2)
-                self.assertTrue(distance >= 8e-10)
+                type_i, type_j = int(types[i]), int(types[j])
+                min_separation = (a.cores[type_i] + a.cores[type_j]) / 2
+                self.assertTrue(distance >= min_separation)
+
+    def test_system_cores_default_to_the_energy_zero(self):
+        a = util.System(
+            2, 300, 8, [[1.363e-134, 9.273e-78]], ff.lennard_jones, 39.948, simulation="md"
+        )
+        expected_sigma = (1.363e-134 / 9.273e-78) ** (1 / 6)
+        assert_almost_equal(a.cores[0] * 1e10, expected_sigma * 1e10, decimal=3)
+
+        b = util.System(
+            2, 300, 8, [[1.0, 1.5e-10, 2.0]], ff.square_well, 39.948, simulation="md"
+        )
+        assert_almost_equal(b.cores[0], 1.5e-10, decimal=12)
+
+        class NeverPositive:
+            def __init__(self, constants):
+                self.constants = constants
+
+            @property
+            def diameter(self):
+                return 1e-10
+
+            def energy(self, dr):
+                return -np.ones_like(np.asarray(dr, dtype=float))
+
+        with self.assertRaisesRegex(ValueError, "repulsive core"):
+            util.System(2, 300, 8, [[1.0]], NeverPositive, 39.948, simulation="md")
+
+        class ZeroDiameter:
+            def __init__(self, constants):
+                self.constants = constants
+
+            @property
+            def diameter(self):
+                return 0.0
+
+            def energy(self, dr):
+                return np.ones_like(np.asarray(dr, dtype=float))
+
+        with self.assertRaisesRegex(ValueError, "ZeroDiameter"):
+            util.System(2, 300, 8, [[1.0]], ZeroDiameter, 39.948, simulation="md")
 
     def test_system_too_big(self):
         with self.assertRaises(AttributeError) as context:
@@ -206,23 +307,23 @@ class TestUtil(unittest.TestCase):
         assert_almost_equal(a.diameters[0] * 1e10, 3.78, decimal=2)
 
     def test_system_single_diameter_applies_to_every_type(self):
-        constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
+        constants = [[1.363e-134, 9.273e-78], FIVE_ANGSTROM_CORE]
         a = util.System(
-            2, 300, 8, constants, ff.lennard_jones, 39.948, simulation="md", diameter=3.0
+            2, 300, 12, constants, ff.lennard_jones, 39.948, simulation="md", diameter=3.0
         )
         assert_almost_equal(a.diameters, [3e-10, 3e-10])
 
     def test_system_diameter_list_is_per_type(self):
-        constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
+        constants = [[1.363e-134, 9.273e-78], FIVE_ANGSTROM_CORE]
         a = util.System(
-            2, 300, 10, constants, ff.lennard_jones, 39.948, simulation="md", diameter=[3.0, 5.0]
+            2, 300, 12, constants, ff.lennard_jones, 39.948, simulation="md", diameter=[3.0, 5.0]
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])
 
     def test_system_diameter_array_is_per_type(self):
-        constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
+        constants = [[1.363e-134, 9.273e-78], FIVE_ANGSTROM_CORE]
         a = util.System(
-            2, 300, 10, constants, ff.lennard_jones, 39.948, simulation="md",
+            2, 300, 12, constants, ff.lennard_jones, 39.948, simulation="md",
             diameter=np.array([3.0, 5.0]),
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -95,7 +95,22 @@ class TestUtil(unittest.TestCase):
                 forcefield=ff.lennard_jones,
                 simulation="md",
             )
-        self.assertTrue("square" in str(context.exception))
+        message = str(context.exception)
+        self.assertTrue("particle" in message)
+        self.assertFalse("square" in message)
+
+    def test_system_square_overlap_raises(self):
+        with self.assertRaises(ValueError) as context:
+            util.System(
+                50,
+                100,
+                20,
+                mass=39.948,
+                constants=[[1.363e-134, 9.273e-78]],
+                forcefield=ff.lennard_jones,
+                simulation="md",
+            )
+        self.assertTrue("diameter" in str(context.exception))
 
     def test_system_random_diameter_override(self):
         a = util.System(
@@ -200,14 +215,14 @@ class TestUtil(unittest.TestCase):
     def test_system_diameter_list_is_per_type(self):
         constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
         a = util.System(
-            2, 300, 8, constants, ff.lennard_jones, 39.948, simulation="md", diameter=[3.0, 5.0]
+            2, 300, 10, constants, ff.lennard_jones, 39.948, simulation="md", diameter=[3.0, 5.0]
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])
 
     def test_system_diameter_array_is_per_type(self):
         constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
         a = util.System(
-            2, 300, 8, constants, ff.lennard_jones, 39.948, simulation="md",
+            2, 300, 10, constants, ff.lennard_jones, 39.948, simulation="md",
             diameter=np.array([3.0, 5.0]),
         )
         assert_almost_equal(a.diameters, [3e-10, 5e-10])

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -117,11 +117,11 @@ class TestUtil(unittest.TestCase):
         self.assertTrue("fit" in message)
 
     def test_system_square_between_core_and_diameter_is_accepted(self):
-        # 100 argon particles in a 40 Angstrom box space 4.0 Angstrom apart:
-        # above the 3.4 Angstrom repulsive core, but below the 3.78 Angstrom
+        # 101 argon particles in a 40 Angstrom box space 3.64 Angstrom apart:
+        # above the 3.37 Angstrom repulsive core, but below the 3.78 Angstrom
         # drawn diameter, which used to be the (overly strict) threshold.
         a = util.System(
-            100,
+            101,
             100,
             40,
             mass=39.948,
@@ -129,7 +129,7 @@ class TestUtil(unittest.TestCase):
             forcefield=ff.lennard_jones,
             simulation="md",
         )
-        assert_equal(a.number_of_particles, 100)
+        assert_equal(a.number_of_particles, 101)
 
     def test_system_random_threshold_is_the_core_not_the_drawn_diameter(self):
         # A diameter=8.0 override only changes how particles are drawn, not
@@ -167,9 +167,9 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(any(distance < 8e-10 for distance in distances))
 
     def test_system_random_two_types_uses_the_mean_of_the_pair_cores(self):
-        constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
+        constants = [ARGON, LARGER]
         state = np.random.get_state()
-        np.random.seed(0)
+        np.random.seed(5)
         try:
             a = util.System(
                 12,
@@ -178,7 +178,7 @@ class TestUtil(unittest.TestCase):
                 init_conf="random",
                 mass=39.948,
                 constants=constants,
-                forcefield=ff.lennard_jones,
+                forcefield=ff.lennard_jones_sigma_epsilon,
                 simulation="md",
             )
         finally:
@@ -198,18 +198,20 @@ class TestUtil(unittest.TestCase):
                 min_separation = (a.cores[type_i] + a.cores[type_j]) / 2
                 self.assertTrue(distance >= min_separation)
 
-    def test_system_cores_default_to_the_energy_zero(self):
+    def test_system_argon_core_equals_sigma(self):
         a = util.System(
             2, 300, 8, [[1.363e-134, 9.273e-78]], ff.lennard_jones, 39.948, simulation="md"
         )
         expected_sigma = (1.363e-134 / 9.273e-78) ** (1 / 6)
         assert_almost_equal(a.cores[0] * 1e10, expected_sigma * 1e10, decimal=3)
 
+    def test_system_square_well_core_equals_sigma(self):
         b = util.System(
             2, 300, 8, [[1.0, 1.5e-10, 2.0]], ff.square_well, 39.948, simulation="md"
         )
         assert_almost_equal(b.cores[0], 1.5e-10, decimal=12)
 
+    def test_system_forcefield_never_positive_raises(self):
         class NeverPositive:
             def __init__(self, constants):
                 self.constants = constants
@@ -223,20 +225,6 @@ class TestUtil(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "repulsive core"):
             util.System(2, 300, 8, [[1.0]], NeverPositive, 39.948, simulation="md")
-
-        class ZeroDiameter:
-            def __init__(self, constants):
-                self.constants = constants
-
-            @property
-            def diameter(self):
-                return 0.0
-
-            def energy(self, dr):
-                return np.ones_like(np.asarray(dr, dtype=float))
-
-        with self.assertRaisesRegex(ValueError, "ZeroDiameter"):
-            util.System(2, 300, 8, [[1.0]], ZeroDiameter, 39.948, simulation="md")
 
     def test_system_too_big(self):
         with self.assertRaises(AttributeError) as context:
@@ -332,10 +320,11 @@ class TestUtil(unittest.TestCase):
         assert_almost_equal(a.diameters, [3e-10, 5e-10])
 
     def test_system_diameter_list_must_match_types(self):
-        constants = [[1.363e-134, 9.273e-78], [1.365e-130, 9.278e-77]]
+        constants = [ARGON, LARGER]
         with self.assertRaises(ValueError):
             util.System(
-                2, 300, 8, constants, ff.lennard_jones, 39.948, simulation="md", diameter=[3.0]
+                2, 300, 8, constants, ff.lennard_jones_sigma_epsilon, 39.948,
+                simulation="md", diameter=[3.0],
             )
 
     def test_system_diameter_must_be_positive(self):
@@ -374,3 +363,18 @@ class TestUtil(unittest.TestCase):
         constants = [[1.363e-134, 9.273e-78]]
         with self.assertRaisesRegex(ValueError, "diameter"):
             util.System(2, 300, 8, constants, NoDiameter, 39.948, simulation="md")
+
+    def test_system_forcefield_with_a_zero_diameter_is_rejected(self):
+        class ZeroDiameter:
+            def __init__(self, constants):
+                self.constants = constants
+
+            @property
+            def diameter(self):
+                return 0.0
+
+            def energy(self, dr):
+                return np.ones_like(np.asarray(dr, dtype=float))
+
+        with self.assertRaisesRegex(ValueError, "ZeroDiameter"):
+            util.System(2, 300, 8, [[1.0]], ZeroDiameter, 39.948, simulation="md")

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -121,7 +121,7 @@ class TestUtil(unittest.TestCase):
     def test_system_square_overlap_raises(self):
         # 50 argon particles in a 20 Angstrom box: at most 25 fit on a
         # square lattice without overlap.
-        with self.assertRaisesRegex(ValueError, "25"):
+        with self.assertRaisesRegex(ValueError, "at most 25 particles"):
             util.System(
                 50,
                 100,
@@ -209,7 +209,7 @@ class TestUtil(unittest.TestCase):
         b = util.System(
             2, 300, 8, [[1.0, sigma, 2.0]], ff.square_well, 39.948, simulation="md"
         )
-        self.assertTrue(b.cores[0] >= sigma)
+        self.assertTrue(sigma <= b.cores[0] <= sigma * 1.002)
 
     def test_system_forcefield_never_positive_raises(self):
         class NeverPositive:

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -55,6 +55,72 @@ class TestUtil(unittest.TestCase):
         assert_equal(a.forces.size, 1)
         assert_equal(a.energies.size, 1)
 
+    def test_system_random_no_overlap(self):
+        state = np.random.get_state()
+        np.random.seed(0)
+        try:
+            a = util.System(
+                30,
+                100,
+                40,
+                init_conf="random",
+                mass=39.948,
+                constants=[[1.363e-134, 9.273e-78]],
+                forcefield=ff.lennard_jones,
+                simulation="md",
+            )
+        finally:
+            np.random.set_state(state)
+        box_length = a.box_length
+        x = a.particles["xposition"]
+        y = a.particles["yposition"]
+        for i in range(a.number_of_particles):
+            for j in range(i + 1, a.number_of_particles):
+                dx = x[i] - x[j]
+                dy = y[i] - y[j]
+                dx -= box_length * np.round(dx / box_length)
+                dy -= box_length * np.round(dy / box_length)
+                distance = np.sqrt(dx**2 + dy**2)
+                self.assertTrue(distance >= a.diameters[0])
+
+    def test_system_random_too_dense_raises(self):
+        with self.assertRaises(ValueError) as context:
+            util.System(
+                200,
+                100,
+                20,
+                init_conf="random",
+                mass=39.948,
+                constants=[[1.363e-134, 9.273e-78]],
+                forcefield=ff.lennard_jones,
+                simulation="md",
+            )
+        self.assertTrue("square" in str(context.exception))
+
+    def test_system_random_diameter_override(self):
+        a = util.System(
+            10,
+            100,
+            40,
+            init_conf="random",
+            mass=39.948,
+            constants=[[1.363e-134, 9.273e-78]],
+            forcefield=ff.lennard_jones,
+            simulation="md",
+            diameter=8.0,
+        )
+        box_length = a.box_length
+        x = a.particles["xposition"]
+        y = a.particles["yposition"]
+        for i in range(a.number_of_particles):
+            for j in range(i + 1, a.number_of_particles):
+                dx = x[i] - x[j]
+                dy = y[i] - y[j]
+                dx -= box_length * np.round(dx / box_length)
+                dy -= box_length * np.round(dy / box_length)
+                distance = np.sqrt(dx**2 + dy**2)
+                self.assertTrue(distance >= 8e-10)
+
     def test_system_too_big(self):
         with self.assertRaises(AttributeError) as context:
             util.System(

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -175,12 +175,12 @@ class System:
             n_max = int(np.floor(self.box_length / core)) ** 2
             l_min = np.ceil(np.sqrt(self.number_of_particles)) * core
             l_min_angstrom = np.ceil(l_min * 1e10 * 10) / 10
-            particle_noun = "particle" if n_max == 1 else "particles"
+            fits = "1 particle fits" if n_max == 1 else f"{n_max} particles fit"
             raise ValueError(
                 f"A square lattice of {self.number_of_particles} particles in a "
                 f"{self.box_length * 1e10:.1f} Angstrom box spaces them {d * 1e10:.2f} "
                 f"Angstrom apart, less than the largest repulsive core of "
-                f"{core * 1e10:.2f} Angstrom; at most {n_max} {particle_noun} fit in this "
+                f"{core * 1e10:.2f} Angstrom; at most {fits} in this "
                 f"box, or a box of at least {l_min_angstrom:.1f} Angstrom fits "
                 f"{self.number_of_particles}."
             )
@@ -198,10 +198,9 @@ class System:
         Particles are placed one at a time by rejection sampling: a
         candidate position for a particle is accepted only if, for every
         already placed particle, the minimum-image distance between them is
-        at least the mean of the two particles' repulsive cores
-        (``self.cores``, indexed by ``self.particles["types"]``). Two
-        particles of different types are kept at least the mean of their two
-        cores apart.
+        at least the two particles' repulsive core, ``self.cores``, one per
+        set of constants. Two particles of different types are kept at least
+        the mean of their two cores apart.
 
         Rejection sampling reaches area fractions of roughly 0.4 to 0.5;
         near that limit the same call may succeed or raise depending on

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -152,7 +152,7 @@ class System:
         """
         m = int(np.ceil(np.sqrt(self.number_of_particles)))
         d = self.box_length / m
-        if self.diameters and d < max(self.diameters):
+        if d < max(self.diameters):
             raise ValueError(
                 f"A square lattice of {self.number_of_particles} particles in a "
                 f"{self.box_length * 1e10:.1f} Angstrom box spaces them {d * 1e10:.2f} "

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -55,9 +55,8 @@ class System:
         values below that are metres mistaken for Angstrom. Defaults to the
         separation at the pair-potential minimum of the forcefield, which the
         forcefield must then provide as its ``diameter`` property. Stored in
-        metres as ``diameters``. This does not affect the separation kept
-        between particles when placing the initial configuration; see the
-        Attributes section below.
+        metres as ``diameters``. This sets how the particles are drawn;
+        placement uses ``cores``.
 
     Attributes
     ----------
@@ -65,8 +64,8 @@ class System:
         Drawn diameter of each particle type, in metres.
     cores: list of float
         Separation at which each type's pair energy falls to zero, in
-        metres; initial configurations keep particles at least this far
-        apart.
+        metres. Particles of one type are placed at least this far apart,
+        and particles of two types at least the mean of their cores apart.
     """
 
     def __init__(
@@ -175,12 +174,14 @@ class System:
         if d < core:
             n_max = int(np.floor(self.box_length / core)) ** 2
             l_min = np.ceil(np.sqrt(self.number_of_particles)) * core
+            l_min_angstrom = np.ceil(l_min * 1e10 * 10) / 10
+            particle_noun = "particle" if n_max == 1 else "particles"
             raise ValueError(
                 f"A square lattice of {self.number_of_particles} particles in a "
                 f"{self.box_length * 1e10:.1f} Angstrom box spaces them {d * 1e10:.2f} "
                 f"Angstrom apart, less than the largest repulsive core of "
-                f"{core * 1e10:.2f} Angstrom; at most {n_max} particles fit in this "
-                f"box, or a box of at least {l_min * 1e10:.1f} Angstrom fits "
+                f"{core * 1e10:.2f} Angstrom; at most {n_max} {particle_noun} fit in this "
+                f"box, or a box of at least {l_min_angstrom:.1f} Angstrom fits "
                 f"{self.number_of_particles}."
             )
         n = 0
@@ -198,7 +199,9 @@ class System:
         candidate position for a particle is accepted only if, for every
         already placed particle, the minimum-image distance between them is
         at least the mean of the two particles' repulsive cores
-        (``self.cores``, indexed by ``self.particles["types"]``).
+        (``self.cores``, indexed by ``self.particles["types"]``). Two
+        particles of different types are kept at least the mean of their two
+        cores apart.
 
         Rejection sampling reaches area fractions of roughly 0.4 to 0.5;
         near that limit the same call may succeed or raise depending on
@@ -265,7 +268,7 @@ class System:
             f"(repulsive core {core_angstrom:.2f} Angstrom, largest "
             f"{largest_core_angstrom:.2f} Angstrom) without overlap in a "
             f"{box_angstrom:.1f} Angstrom box after {PLACEMENT_ATTEMPTS} attempts "
-            f"(area fraction {area_fraction:.2f}); reduce the number of particles or "
+            f"(requested area fraction {area_fraction:.2f}); reduce the number of particles or "
             "use a larger box; a square lattice (init_conf='square') packs more "
             "densely than random placement and may still fit."
         )
@@ -300,10 +303,10 @@ class System:
 
         Raises:
             ValueError: If an iterable is given whose length differs from the
-                number of sets of constants, if any diameter is not positive,
-                if any diameter looks like a value in metres rather than
-                Angstrom, or if ``None`` is given and the forcefield has no
-                ``diameter`` property.
+                number of sets of constants, if any diameter is not finite
+                or not positive, if any diameter looks like a value in
+                metres rather than Angstrom, or if ``None`` is given and the
+                forcefield has no ``diameter`` property.
         """
         if diameter is None:
             self.diameters = []
@@ -336,6 +339,8 @@ class System:
                 f"constants, but got {len(values)}"
             )
         for value in values:
+            if not np.isfinite(value):
+                raise ValueError(f"Every diameter must be finite, but got {value}")
             if value <= 0:
                 raise ValueError(f"Every diameter must be positive, but got {value}")
             if value < 0.01:
@@ -346,24 +351,37 @@ class System:
         self.diameters = [value * 1e-10 for value in values]
 
     def setup_cores(self) -> None:
-        """Separation at which the pair energy falls to zero, in metres, one
-        per set of constants. Particles closer than this sit inside each
-        other's repulsive core, so the initial configurations keep them at
-        least this far apart. The ``diameter=`` override does not affect it.
+        """Set the separation at which each forcefield's pair energy falls
+        to zero, in metres, one per set of constants. Particles closer than
+        this sit inside each other's repulsive core, so the initial
+        configurations keep them at least this far apart.
 
         Raises:
-            ValueError: If a forcefield's pair energy never falls from
-                positive to non-positive between 0.1 and 50 Angstrom, so it
-                has no repulsive core on that range.
+            ValueError: If a forcefield's ``energy`` does not return one
+                value per separation, if its pair energy is positive at
+                every grid point between 0.1 and 50 Angstrom (suggesting its
+                constants are in the wrong units), or if its pair energy
+                never falls from positive to non-positive on that range, so
+                it has no repulsive core there.
         """
         r = np.logspace(-11, np.log10(5e-9), 4000)
         self.cores = []
         for c in self.constants:
             forcefield = self.forcefield(c)
             energy = np.asarray(forcefield.energy(r), dtype=float)
+            if energy.shape != r.shape:
+                raise ValueError(
+                    f"{type(forcefield).__name__}.energy must return one value per "
+                    f"separation; got shape {energy.shape} for {r.shape[0]} separations"
+                )
             positive = energy > 0
             crossings = np.flatnonzero(positive[:-1] & ~positive[1:])
             if crossings.size == 0:
+                if positive.all():
+                    raise ValueError(
+                        f"{type(forcefield).__name__}: the pair energy is still "
+                        "positive at 50 Angstrom; check the units of the constants"
+                    )
                 raise ValueError(
                     f"{type(forcefield).__name__} has no repulsive core: its pair "
                     "energy never falls from positive to zero between 0.1 and 50 "

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -6,6 +6,10 @@ import numpy as np
 
 from pylj import mc, md
 
+#: Number of rejection-sampling attempts made for a single particle in
+#: :meth:`System.random` before it gives up and raises ``ValueError``.
+PLACEMENT_ATTEMPTS = 1000
+
 
 class System:
     """Simulation system.
@@ -38,6 +42,8 @@ class System:
         The way that the particles are initially positioned. Should be one of:
         - 'square'
         - 'random'
+        Both raise ``ValueError`` if the particles cannot be placed without
+        their repulsive cores overlapping.
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     cut_off: float (optional)
@@ -49,7 +55,9 @@ class System:
         values below that are metres mistaken for Angstrom. Defaults to the
         separation at the pair-potential minimum of the forcefield, which the
         forcefield must then provide as its ``diameter`` property. Stored in
-        metres as ``diameters``.
+        metres as ``diameters``. This does not affect the separation kept
+        between particles when placing the initial configuration; see
+        ``cores``.
     """
 
     def __init__(
@@ -80,6 +88,8 @@ class System:
         self.types = None
         self.diameters: list[float] = []
         self.setup_diameters(diameter)
+        self.cores: list[float] = []
+        self.setup_cores()
         self.setup_types()
         if box_length <= 600:
             self.box_length = box_length * 1e-10
@@ -147,18 +157,22 @@ class System:
         Raises:
             ValueError: If the lattice spacing, ``box_length`` divided by
                 ``ceil(sqrt(number_of_particles))``, is less than the
-                largest drawn diameter. Reduce the number of particles or
-                use a larger box.
+                largest repulsive core (``self.cores``). Reduce the number
+                of particles or use a larger box.
         """
         m = int(np.ceil(np.sqrt(self.number_of_particles)))
         d = self.box_length / m
-        if d < max(self.diameters):
+        core = max(self.cores)
+        if d < core:
+            n_max = int(np.floor(self.box_length / core)) ** 2
+            l_min = np.ceil(np.sqrt(self.number_of_particles)) * core
             raise ValueError(
                 f"A square lattice of {self.number_of_particles} particles in a "
                 f"{self.box_length * 1e10:.1f} Angstrom box spaces them {d * 1e10:.2f} "
-                f"Angstrom apart, less than the particle diameter of "
-                f"{max(self.diameters) * 1e10:.2f} Angstrom; reduce the number of "
-                "particles or use a larger box."
+                f"Angstrom apart, less than the largest repulsive core of "
+                f"{core * 1e10:.2f} Angstrom; at most {n_max} particles fit in this "
+                f"box, or a box of at least {l_min * 1e10:.1f} Angstrom fits "
+                f"{self.number_of_particles}."
             )
         n = 0
         for i in range(0, m):
@@ -174,55 +188,76 @@ class System:
         Particles are placed one at a time by rejection sampling: a
         candidate position for a particle is accepted only if, for every
         already placed particle, the minimum-image distance between them is
-        at least the mean of the two particles' diameters (``self.diameters``,
-        indexed by ``self.particles["types"]``).
+        at least the mean of the two particles' repulsive cores
+        (``self.cores``, indexed by ``self.particles["types"]``).
 
-        Rejection sampling of non-overlapping circles reaches area fractions
-        of only around 0.4 to 0.5 (a reduced density N sigma^2 / L^2 of
-        about 0.5 for argon-like particles), well below liquid densities.
-        Near that limit, whether a given call succeeds or raises depends on
-        the random draw, so the same arguments may not always behave the
-        same way.
+        With the default constants, rejection sampling reaches area
+        fractions of roughly 0.4 to 0.5; near that limit the same call may
+        succeed or raise depending on the random draw.
 
         Raises:
-            ValueError: If 1000 candidate positions are rejected for a
-                single particle, which suggests the particles are too large,
-                or too many, for the box. Reduce the number of particles or
-                use a larger box.
+            ValueError: If :data:`PLACEMENT_ATTEMPTS` candidate positions are
+                rejected for a single particle, which suggests the particles
+                are too large, or too many, for the box. Reduce the number
+                of particles or use a larger box.
         """
-        num_part = self.number_of_particles
+        x = self.particles["xposition"]
+        y = self.particles["yposition"]
+        for i in range(self.number_of_particles):
+            x[i], y[i] = self._place_particle(i, x, y)
+
+    def _place_particle(
+        self, index: int, placed_x: np.ndarray, placed_y: np.ndarray
+    ) -> tuple[float, float]:
+        """Find a non-overlapping position for one particle by rejection sampling.
+
+        Args:
+            index: Index of the particle being placed into
+                ``self.particles["types"]``.
+            placed_x: x positions of the particles already placed, indexed
+                0 to ``index - 1``.
+            placed_y: y positions of the particles already placed, indexed
+                0 to ``index - 1``.
+
+        Returns:
+            An (x, y) position, in metres, at least the mean of the two
+            particles' repulsive cores from every already-placed particle.
+
+        Raises:
+            ValueError: If :data:`PLACEMENT_ATTEMPTS` candidate positions are
+                rejected.
+        """
         box_length = self.box_length
         types = self.particles["types"]
-        max_attempts = 1000
-        for i in range(num_part):
-            type_i = int(types[i])
-            for _attempt in range(max_attempts):
-                x = np.random.uniform(0, box_length)
-                y = np.random.uniform(0, box_length)
-                placed = True
-                for j in range(i):
-                    type_j = int(types[j])
-                    min_separation = (self.diameters[type_i] + self.diameters[type_j]) / 2
-                    dx = x - self.particles[j]["xposition"]
-                    dy = y - self.particles[j]["yposition"]
-                    dx -= box_length * np.round(dx / box_length)
-                    dy -= box_length * np.round(dy / box_length)
-                    if np.sqrt(dx**2 + dy**2) < min_separation:
-                        placed = False
-                        break
-                if placed:
-                    self.particles[i]["xposition"] = x
-                    self.particles[i]["yposition"] = y
+        type_i = int(types[index])
+        for _attempt in range(PLACEMENT_ATTEMPTS):
+            x = np.random.uniform(0, box_length)
+            y = np.random.uniform(0, box_length)
+            for j in range(index):
+                min_separation = (self.cores[type_i] + self.cores[int(types[j])]) / 2
+                dx = x - placed_x[j]
+                dy = y - placed_y[j]
+                # minimum-image convention: wrap the separation to the
+                # nearest periodic copy of particle j
+                dx -= box_length * np.round(dx / box_length)
+                dy -= box_length * np.round(dy / box_length)
+                if np.sqrt(dx**2 + dy**2) < min_separation:
                     break
             else:
-                diameter_angstrom = self.diameters[type_i] * 1e10
-                box_angstrom = box_length * 1e10
-                raise ValueError(
-                    f"Could not place particle {i + 1} of {num_part} (diameter "
-                    f"{diameter_angstrom:.2f} Angstrom) without overlap in a "
-                    f"{box_angstrom:.1f} Angstrom box after {max_attempts} "
-                    "attempts; reduce the number of particles or use a larger box."
-                )
+                return x, y
+        core_angstrom = self.cores[type_i] * 1e10
+        box_angstrom = box_length * 1e10
+        area_fraction = (
+            self.number_of_particles * np.pi * (max(self.cores) / 2) ** 2 / box_length**2
+        )
+        raise ValueError(
+            f"Could not place particle {index + 1} of {self.number_of_particles} "
+            f"(repulsive core {core_angstrom:.2f} Angstrom) without overlap in a "
+            f"{box_angstrom:.1f} Angstrom box after {PLACEMENT_ATTEMPTS} attempts "
+            f"(area fraction {area_fraction:.2f}); reduce the number of particles or "
+            "use a larger box; a square lattice (init_conf='square') packs more "
+            "densely than random placement and may still fit."
+        )
 
     def setup_types(self):
         """Sets the long constants and types arrays of the particles
@@ -273,6 +308,11 @@ class System:
                         "caller must pass diameter= to initialise. See the bring "
                         "your own forcefield documentation."
                     ) from error
+                if not np.isfinite(value) or value <= 0:
+                    raise ValueError(
+                        f"{type(forcefield).__name__}.diameter must be a positive, "
+                        f"finite value in metres, but got {value}"
+                    )
                 self.diameters.append(value)
             return
         if isinstance(diameter, Iterable):
@@ -293,6 +333,49 @@ class System:
                     "metres. An Angstrom is 1e-10 metres."
                 )
         self.diameters = [value * 1e-10 for value in values]
+
+    def setup_cores(self) -> None:
+        """Separation at which the pair energy falls to zero, in metres, one
+        per set of constants. Particles closer than this sit inside each
+        other's repulsive core, so the initial configurations keep them at
+        least this far apart. The ``diameter=`` override does not affect it.
+
+        Raises:
+            ValueError: If a forcefield's pair energy never falls from
+                positive to non-positive between 0.1 and 50 Angstrom, so it
+                has no repulsive core on that range.
+        """
+        r = np.logspace(-11, np.log10(5e-9), 4000)
+        self.cores = []
+        for c in self.constants:
+            forcefield = self.forcefield(c)
+            energy = np.asarray(forcefield.energy(r), dtype=float)
+            positive = energy > 0
+            crossings = np.flatnonzero(positive[:-1] & ~positive[1:])
+            if crossings.size == 0:
+                raise ValueError(
+                    f"{type(forcefield).__name__} has no repulsive core: its pair "
+                    "energy never falls from positive to zero between 0.1 and 50 "
+                    "Angstrom"
+                )
+            i = int(crossings[-1])
+            r0, r1 = r[i], r[i + 1]
+            e0, e1 = energy[i], energy[i + 1]
+            if np.isfinite(e0) and np.isfinite(e1):
+                # linear interpolation to the point where the energy is zero
+                core = r0 + (r1 - r0) * (-e0) / (e1 - e0)
+            else:
+                # a discontinuous step (e.g. an infinite repulsive wall): the
+                # first non-positive grid point is a safe, slightly
+                # conservative estimate
+                core = r1
+            if not np.isfinite(core) or core <= 0:
+                raise ValueError(
+                    f"{type(forcefield).__name__} has no repulsive core: its pair "
+                    "energy never falls from positive to zero between 0.1 and 50 "
+                    "Angstrom"
+                )
+            self.cores.append(float(core))
 
     def compute_force(self):
         """Maps to the md.compute_force function, storing what it returns."""

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -56,8 +56,17 @@ class System:
         separation at the pair-potential minimum of the forcefield, which the
         forcefield must then provide as its ``diameter`` property. Stored in
         metres as ``diameters``. This does not affect the separation kept
-        between particles when placing the initial configuration; see
-        ``cores``.
+        between particles when placing the initial configuration; see the
+        Attributes section below.
+
+    Attributes
+    ----------
+    diameters: list of float
+        Drawn diameter of each particle type, in metres.
+    cores: list of float
+        Separation at which each type's pair energy falls to zero, in
+        metres; initial configurations keep particles at least this far
+        apart.
     """
 
     def __init__(
@@ -191,9 +200,9 @@ class System:
         at least the mean of the two particles' repulsive cores
         (``self.cores``, indexed by ``self.particles["types"]``).
 
-        With the default constants, rejection sampling reaches area
-        fractions of roughly 0.4 to 0.5; near that limit the same call may
-        succeed or raise depending on the random draw.
+        Rejection sampling reaches area fractions of roughly 0.4 to 0.5;
+        near that limit the same call may succeed or raise depending on
+        the random draw.
 
         Raises:
             ValueError: If :data:`PLACEMENT_ATTEMPTS` candidate positions are
@@ -230,29 +239,31 @@ class System:
         box_length = self.box_length
         types = self.particles["types"]
         type_i = int(types[index])
+        cores = np.asarray(self.cores)
+        thresholds = (cores[type_i] + cores[[int(t) for t in types[:index]]]) / 2
         for _attempt in range(PLACEMENT_ATTEMPTS):
             x = np.random.uniform(0, box_length)
             y = np.random.uniform(0, box_length)
-            for j in range(index):
-                min_separation = (self.cores[type_i] + self.cores[int(types[j])]) / 2
-                dx = x - placed_x[j]
-                dy = y - placed_y[j]
-                # minimum-image convention: wrap the separation to the
-                # nearest periodic copy of particle j
-                dx -= box_length * np.round(dx / box_length)
-                dy -= box_length * np.round(dy / box_length)
-                if np.sqrt(dx**2 + dy**2) < min_separation:
-                    break
-            else:
+            dx = x - placed_x[:index]
+            dy = y - placed_y[:index]
+            # minimum-image convention: wrap the separation to the
+            # nearest periodic copy of each already-placed particle
+            dx -= box_length * np.round(dx / box_length)
+            dy -= box_length * np.round(dy / box_length)
+            separations = np.sqrt(dx**2 + dy**2)
+            if np.all(separations >= thresholds):
                 return x, y
         core_angstrom = self.cores[type_i] * 1e10
         box_angstrom = box_length * 1e10
+        largest_core_angstrom = max(self.cores) * 1e10
         area_fraction = (
-            self.number_of_particles * np.pi * (max(self.cores) / 2) ** 2 / box_length**2
+            sum(np.pi * (self.cores[int(t)] / 2) ** 2 for t in self.particles["types"])
+            / box_length**2
         )
         raise ValueError(
             f"Could not place particle {index + 1} of {self.number_of_particles} "
-            f"(repulsive core {core_angstrom:.2f} Angstrom) without overlap in a "
+            f"(repulsive core {core_angstrom:.2f} Angstrom, largest "
+            f"{largest_core_angstrom:.2f} Angstrom) without overlap in a "
             f"{box_angstrom:.1f} Angstrom box after {PLACEMENT_ATTEMPTS} attempts "
             f"(area fraction {area_fraction:.2f}); reduce the number of particles or "
             "use a larger box; a square lattice (init_conf='square') packs more "
@@ -369,12 +380,6 @@ class System:
                 # first non-positive grid point is a safe, slightly
                 # conservative estimate
                 core = r1
-            if not np.isfinite(core) or core <= 0:
-                raise ValueError(
-                    f"{type(forcefield).__name__} has no repulsive core: its pair "
-                    "energy never falls from positive to zero between 0.1 and 50 "
-                    "Angstrom"
-                )
             self.cores.append(float(core))
 
     def compute_force(self):

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -141,10 +141,25 @@ class System:
         """
         return int((self.number_of_particles - 1) * self.number_of_particles / 2)
 
-    def square(self):
-        """Places the particles on a square lattice."""
+    def square(self) -> None:
+        """Places the particles on a square lattice.
+
+        Raises:
+            ValueError: If the lattice spacing, ``box_length`` divided by
+                ``ceil(sqrt(number_of_particles))``, is less than the
+                largest drawn diameter. Reduce the number of particles or
+                use a larger box.
+        """
         m = int(np.ceil(np.sqrt(self.number_of_particles)))
         d = self.box_length / m
+        if self.diameters and d < max(self.diameters):
+            raise ValueError(
+                f"A square lattice of {self.number_of_particles} particles in a "
+                f"{self.box_length * 1e10:.1f} Angstrom box spaces them {d * 1e10:.2f} "
+                f"Angstrom apart, less than the particle diameter of "
+                f"{max(self.diameters) * 1e10:.2f} Angstrom; reduce the number of "
+                "particles or use a larger box."
+            )
         n = 0
         for i in range(0, m):
             for j in range(0, m):
@@ -162,11 +177,18 @@ class System:
         at least the mean of the two particles' diameters (``self.diameters``,
         indexed by ``self.particles["types"]``).
 
+        Rejection sampling of non-overlapping circles reaches area fractions
+        of only around 0.4 to 0.5 (a reduced density N sigma^2 / L^2 of
+        about 0.5 for argon-like particles), well below liquid densities.
+        Near that limit, whether a given call succeeds or raises depends on
+        the random draw, so the same arguments may not always behave the
+        same way.
+
         Raises:
             ValueError: If 1000 candidate positions are rejected for a
                 single particle, which suggests the particles are too large,
-                or too many, for the box. Use ``init_conf='square'`` or a
-                larger box instead.
+                or too many, for the box. Reduce the number of particles or
+                use a larger box.
         """
         num_part = self.number_of_particles
         box_length = self.box_length
@@ -193,13 +215,13 @@ class System:
                     self.particles[i]["yposition"] = y
                     break
             else:
-                diameter_angstrom = max(self.diameters) * 1e10
+                diameter_angstrom = self.diameters[type_i] * 1e10
                 box_angstrom = box_length * 1e10
                 raise ValueError(
-                    f"Could not place {num_part} particles of diameter "
-                    f"{diameter_angstrom:.2f} Angstrom without overlap in a "
+                    f"Could not place particle {i + 1} of {num_part} (diameter "
+                    f"{diameter_angstrom:.2f} Angstrom) without overlap in a "
                     f"{box_angstrom:.1f} Angstrom box after {max_attempts} "
-                    "attempts; use init_conf='square' or a larger box."
+                    "attempts; reduce the number of particles or use a larger box."
                 )
 
     def setup_types(self):

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -153,11 +153,54 @@ class System:
                     self.particles[n]["yposition"] = (j + 0.5) * d
                     n += 1
 
-    def random(self):
-        """Places the particles at random positions."""
+    def random(self) -> None:
+        """Places the particles at random positions, without overlap.
+
+        Particles are placed one at a time by rejection sampling: a
+        candidate position for a particle is accepted only if, for every
+        already placed particle, the minimum-image distance between them is
+        at least the mean of the two particles' diameters (``self.diameters``,
+        indexed by ``self.particles["types"]``).
+
+        Raises:
+            ValueError: If 1000 candidate positions are rejected for a
+                single particle, which suggests the particles are too large,
+                or too many, for the box. Use ``init_conf='square'`` or a
+                larger box instead.
+        """
         num_part = self.number_of_particles
-        self.particles["xposition"] = np.random.uniform(0, self.box_length, num_part)
-        self.particles["yposition"] = np.random.uniform(0, self.box_length, num_part)
+        box_length = self.box_length
+        types = self.particles["types"]
+        max_attempts = 1000
+        for i in range(num_part):
+            type_i = int(types[i])
+            for _attempt in range(max_attempts):
+                x = np.random.uniform(0, box_length)
+                y = np.random.uniform(0, box_length)
+                placed = True
+                for j in range(i):
+                    type_j = int(types[j])
+                    min_separation = (self.diameters[type_i] + self.diameters[type_j]) / 2
+                    dx = x - self.particles[j]["xposition"]
+                    dy = y - self.particles[j]["yposition"]
+                    dx -= box_length * np.round(dx / box_length)
+                    dy -= box_length * np.round(dy / box_length)
+                    if np.sqrt(dx**2 + dy**2) < min_separation:
+                        placed = False
+                        break
+                if placed:
+                    self.particles[i]["xposition"] = x
+                    self.particles[i]["yposition"] = y
+                    break
+            else:
+                diameter_angstrom = max(self.diameters) * 1e10
+                box_angstrom = box_length * 1e10
+                raise ValueError(
+                    f"Could not place {num_part} particles of diameter "
+                    f"{diameter_angstrom:.2f} Angstrom without overlap in a "
+                    f"{box_angstrom:.1f} Angstrom box after {max_attempts} "
+                    "attempts; use init_conf='square' or a larger box."
+                )
 
     def setup_types(self):
         """Sets the long constants and types arrays of the particles


### PR DESCRIPTION
## Summary

`System.random()` and `System.square()` refused to overlap particles using `self.diameters`, the separation at the pair-potential minimum (2^(1/6) sigma for Lennard-Jones). That threshold rules out any square lattice above a reduced density of about 0.79, so it ruled out a dense solid, and it checked the wrong quantity: the failure in #82 was particles starting inside each other's repulsive core, which is the separation at which the pair energy falls to zero (sigma for Lennard-Jones and the square well), not the potential minimum.

`System` now computes `self.cores`, one value per set of constants, by locating the largest separation at which each forcefield's `energy` falls from positive to zero or negative, on a logarithmic grid between 0.1 and 50 Angstrom. `random()` and `square()` use this as their overlap threshold instead of `self.diameters`. The `diameter` argument to `md.initialise`/`mc.initialise`, which only controls how large particles are drawn, no longer has any bearing on placement.

`random()` places particles one at a time by rejection sampling, accepting a candidate position only if it is at least the mean of the two particles' cores from every already-placed particle. After 1000 rejected attempts it raises `ValueError` naming the particle index reached, the repulsive core of the particle that failed, the area fraction of the configuration requested, and both remedies: reduce the number of particles or use a larger box, and that a square lattice packs more densely and may still fit.

`square()` raises `ValueError` if the lattice spacing is below the largest repulsive core, naming the spacing and the core, and reporting both the largest particle count that fits in the given box and the smallest box that fits the given particle count.

The Monte Carlo example notebook places fifty particles, half with a roughly 11 Angstrom repulsive core, in a 100 Angstrom box; the example on master used a 45 Angstrom box, which spaced them 5.6 Angstrom apart and overlapped.

A forcefield-supplied `diameter`, not just a caller-supplied one, is now validated as finite and positive, naming the forcefield.

Closes #82.
