### PR TITLE
Vectorise the pairwise loops and reuse the forces when sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to pylj are recorded here. The format follows
 - The atomic mass unit used for initial velocities is the CODATA value; initial velocities and computed temperatures move by up to 4e-5 relative.
 - `energy` and `force` on the forcefields return a Python float for scalar input, rather than `np.float64`; a one-element list, such as to `square_well.energy`, returns a one-element array rather than a float.
 - `pairwise.compute_force` evaluates each forcefield only on the pairs of its own types, instead of passing every forcefield the full distance array with the other types' entries zeroed.
-- Pair distances and accelerations are computed with vectorised NumPy. `pairwise.dist` returns `(dr, dx, dy)` and no longer takes or returns particle types; `pairwise.calculate_pressure` takes the pair distances and forces directly, `(distances, forces, box_length, number_of_particles, temperature)`.
+- Pair distances and accelerations are computed with vectorised NumPy. `pairwise.dist` returns `(dr, dx, dy)` and no longer takes or returns particle types; `pairwise.calculate_pressure` takes the pair distances and forces directly, `(distances, forces, box_length, number_of_particles, temperature)`, and `md.sample` feeds it the forces stored by the last force evaluation rather than recomputing them.
 
 ### Fixed
 
@@ -44,7 +44,6 @@ All notable changes to pylj are recorded here. The format follows
 - A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units) is refused with a clear message.
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
-- Pressure sampling no longer recomputes the pair forces; `md.sample` reuses the forces from the last integration step.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to pylj are recorded here. The format follows
 - The atomic mass unit used for initial velocities is the CODATA value; initial velocities and computed temperatures move by up to 4e-5 relative.
 - `energy` and `force` on the forcefields return a Python float for scalar input, rather than `np.float64`; a one-element list, such as to `square_well.energy`, returns a one-element array rather than a float.
 - `pairwise.compute_force` evaluates each forcefield only on the pairs of its own types, instead of passing every forcefield the full distance array with the other types' entries zeroed.
+- Pair distances and accelerations are computed with vectorised NumPy. `pairwise.dist` returns `(dr, dx, dy)` and no longer takes or returns particle types; `pairwise.calculate_pressure` takes the pair distances and forces directly, `(distances, forces, box_length, number_of_particles, temperature)`.
 
 ### Fixed
 
@@ -43,8 +44,10 @@ All notable changes to pylj are recorded here. The format follows
 - A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units) is refused with a clear message.
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
+- Pressure sampling no longer recomputes the pair forces; `md.sample` reuses the forces from the last integration step.
 
 ### Removed
 
 - `pairwise.heat_bath`; `md.heat_bath` is the implementation (#76).
 - `pylj/sample.py`, `point_size` on forcefields, `System.type_identifiers`, `pairwise.create_dist_identifiers`, `MANIFEST.in`, and the Code Climate upload from CI.
+- `pairwise.separation`, `pairwise.pbc_correction`, `pairwise.second_law`, and the deprecated `pairwise.lennard_jones_energy` and `pairwise.lennard_jones_force` wrappers.

--- a/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
+++ b/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
@@ -87,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are going to use the software pylj. This is a Python library, which means it is a collection of functions to enable the simulation of molecular dynamics. An example of a function in pylj is the `pairwise.lennard_jones_energy`, which can be used similar to the `lennard_jones` function that you have defined above."
+    "We are going to use the software pylj. This is a Python library, which means it is a collection of functions to enable the simulation of molecular dynamics. An example is the `forcefields.lennard_jones` class: given the constants A and B, its `energy` method does the same job as the `lennard_jones` function that you have defined above."
    ]
   },
   {
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "r = np.linspace( 3e-10, 8e-10, 100 )\n",
-    "E = forcefields.lennard_jones(r, [1.36e-134, 9.27e-78])\n",
+    "E = forcefields.lennard_jones([1.36e-134, 9.27e-78]).energy(r)\n",
     "\n",
     "plt.plot( r, E )\n",
     "plt.xlabel( '$r/m$' )\n",

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -22,7 +22,7 @@ def initialise(
     number_of_particles: int
         Number of particles to simulate.
     temperature: float
-        Initial temperature of the particles, in Kelvin.
+        Initial temperature of the particles, in kelvin.
     box_length: float
         Length of a single dimension of the simulation square, in Angstrom.
     init_conf: string

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -98,7 +98,7 @@ def velocity_verlet(
     timestep_length: float
         Length for each Velocity-Verlet integration step, in seconds.
     box_length: float
-        Length of a single dimension of the simulation square, in Angstrom.
+        Length of a single dimension of the simulation square, in metres.
 
     Returns
     -------
@@ -235,7 +235,7 @@ def update_positions(
     timestep_length: float
         Length for each Velocity-Verlet integration step, in seconds.
     box_length: float
-        Length of a single dimension of the simulation square, in Angstrom.
+        Length of a single dimension of the simulation square, in metres.
 
     Returns
     -------
@@ -318,7 +318,7 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     particles: util.particle_dt, array_like
         Information about the particles.
     box_length: float
-        Length of a single dimension of the simulation square, in Angstrom.
+        Length of a single dimension of the simulation square, in metres.
     cut_off: float
         The distance greater than which the forces between particles is taken
         as zero.

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -141,7 +141,7 @@ def sample(particles, box_length, initial_particles, system):
     particles: util.particle_dt, array_like
         Information about the particles.
     box_length: float
-        Length of a single dimension of the simulation square, in Angstrom.
+        Length of a single dimension of the simulation square, in metres.
     initial_particles: util.particle_dt, array-like
         Information about the initial particle conformation.
     system: System

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -320,8 +320,8 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     box_length: float
         Length of a single dimension of the simulation square, in metres.
     cut_off: float
-        The distance greater than which the forces between particles is taken
-        as zero.
+        The distance beyond which the force between two particles is taken
+        to be zero.
     constants: float, array_like (optional)
         The constants associated with the particular forcefield used, e.g. for
         the function forcefields.lennard_jones, theses are [A, B]

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -25,7 +25,7 @@ def initialise(
     number_of_particles: int
         Number of particles to simulate.
     temperature: float
-        Initial temperature of the particles, in Kelvin.
+        Initial temperature of the particles, in kelvin.
     box_length: float
         Length of a single dimension of the simulation square, in Angstrom.
     init_conf: string
@@ -371,7 +371,7 @@ def heat_bath(particles: np.ndarray, mass: float, bath_temperature: float) -> np
         mass: The mass of the particles being simulated, in atomic mass
             units.
         bath_temperature: The desired temperature of the simulation, in
-            Kelvin.
+            kelvin.
 
     Returns:
         The particles with velocities rescaled in place; the same array is

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -157,13 +157,11 @@ def sample(particles, box_length, initial_particles, system):
     temperature_new = calculate_temperature(particles, system.mass)
     system.temperature_sample = np.append(system.temperature_sample, temperature_new)
     pressure_new = heavy.calculate_pressure(
-        particles,
+        system.distances,
+        system.forces,
         box_length,
+        particles.size,
         temperature_new,
-        system.cut_off,
-        system.constants,
-        system.forcefield,
-        system.mass
     )
     msd_new = calculate_msd(particles, initial_particles, box_length)
     system.pressure_sample = np.append(system.pressure_sample, pressure_new)

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -136,6 +136,10 @@ def velocity_verlet(
 def sample(particles, box_length, initial_particles, system):
     """Sample parameters of interest in the simulation.
 
+    The pressure is calculated from the pair distances and forces stored on
+    the system by the last force evaluation, not from the current particle
+    positions.
+
     Parameters
     ----------
     particles: util.particle_dt, array_like

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -152,49 +152,36 @@ def lennard_jones_force(A, B, dr):
 
 
 def calculate_pressure(
-    particles, box_length, temperature, cut_off, constants, forcefield, mass
+    distances, forces, box_length, number_of_particles, temperature
 ):
-    r"""Calculates the instantaneous pressure of the simulation cell, found
-    with the following relationship:
+    r"""Calculate the instantaneous pressure of the simulation cell in two
+    dimensions, from the pair forces already computed for the configuration:
+
     .. math::
-        p = \langle \rho k_b T \rangle + \bigg\langle \frac{1}{3V}\sum_{i}
-        \sum_{j<i} \mathbf{r}_{ij}\mathbf{f}_{ij} \bigg\rangle
+        p = \frac{N k_B T}{L^2} + \frac{1}{2 L^2} \sum_{i} \sum_{j < i}
+        r_{ij} f_{ij}
 
     Parameters
     ----------
-    particles: util.particle_dt, array_like
-        Information about the particles.
+    distances: float, array_like
+        The distance between each pair of particles, in metres.
+    forces: float, array_like
+        The force between each pair of particles, in Newtons.
     box_length: float
-        Length of a single dimension of the simulation square, in Angstrom.
+        Length of a single dimension of the simulation square, in metres.
+    number_of_particles: int
+        The number of particles in the simulation.
     temperature: float
-        Instantaneous temperature of the simulation.
-    cut_off: float
-        The distance greater than which the forces between particles is taken
-        as zero.
-    constants: float, array_like (optional)
-        The constants associated with the particular forcefield used, e.g. for
-        the function forcefields.lennard_jones, theses are [A, B]
-    forcefield: function (optional)
-        The particular forcefield to be used to find the energy and forces.
-    mass: float (optional)
-        The mass of the particle being simulated (units of atomic mass units).
+        Instantaneous temperature of the simulation, in Kelvin.
 
     Returns
     -------
     float:
         Instantaneous pressure of the simulation.
     """
-    particles, distances, forces, energies = heavy.compute_force(
-        particles, box_length, cut_off, constants, forcefield, mass
-        )
-    pres = np.sum(forces * distances)
-    pres = 1.0 / (2 * box_length * box_length) * pres + (
-        particles["xposition"].size
-        / (box_length * box_length)
-        * BOLTZMANN
-        * temperature
-    )
-    return pres
+    virial = np.sum(forces * distances) / (2 * box_length * box_length)
+    ideal = number_of_particles * BOLTZMANN * temperature / (box_length * box_length)
+    return virial + ideal
 
 
 def dist(xposition, yposition, box_length):

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -74,7 +74,7 @@ def update_accelerations(particles, f, m, dx, dy, dr):
     particles: util.particle_dt, array_like
         Information about the particles.
     f: float, array_like
-        The force on each pair of particles, in Newtons.
+        The force on each pair of particles, in newtons.
     m: float
         Mass of the particles, in kilograms.
     dx: float, array_like
@@ -117,13 +117,13 @@ def calculate_pressure(
     distances: float, array_like
         The distance between each pair of particles, in metres.
     forces: float, array_like
-        The force between each pair of particles, in Newtons.
+        The force between each pair of particles, in newtons.
     box_length: float
         Length of a single dimension of the simulation square, in metres.
     number_of_particles: int
         The number of particles in the simulation.
     temperature: float
-        Instantaneous temperature of the simulation, in Kelvin.
+        Instantaneous temperature of the simulation, in kelvin.
 
     Returns
     -------

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -15,8 +15,8 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     box_length: float
         Length of a single dimension of the simulation square, in metres.
     cut_off: float
-        The distance greater than which the forces between particles is taken
-        as zero.
+        The distance beyond which the force between two particles is taken
+        to be zero.
     constants: float, array_like (optional)
         The constants associated with the particular forcefield used, e.g. for
         the function forcefields.lennard_jones, theses are [A, B]

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -13,7 +13,7 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     particles: util.particle_dt, array_like
         Information about the particles.
     box_length: float
-        Length of a single dimension of the simulation square, in Angstrom.
+        Length of a single dimension of the simulation square, in metres.
     cut_off: float
         The distance greater than which the forces between particles is taken
         as zero.

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from pylj import pairwise as heavy
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
 
 
@@ -15,20 +14,20 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     box_length: float
         Length of a single dimension of the simulation square, in metres.
     cut_off: float
-        The distance beyond which the force between two particles is taken
-        to be zero.
-    constants: float, array_like (optional)
+        The separation beyond which the pair energy and force are taken to be
+        zero, in metres.
+    constants: float, array_like
         The constants associated with the particular forcefield used, e.g. for
-        the function forcefields.lennard_jones, theses are [A, B]
-    forcefield: function (optional)
+        the class forcefields.lennard_jones, these are [A, B]
+    forcefield: class
         The particular forcefield to be used to find the energy and forces.
-    mass: float (optional)
+    mass: float
         The mass of the particle being simulated (units of atomic mass units).
 
     Returns
     -------
     util.particle_dt, array_like
-        Information about particles, with updated accelerations and forces.
+        Information about particles, with updated accelerations.
     float, array_like
         Current distances between pairs of particles in the simulation.
     float, array_like
@@ -39,7 +38,7 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     particles["xacceleration"] = np.zeros(particles["xacceleration"].size)
     particles["yacceleration"] = np.zeros(particles["yacceleration"].size)
     mass_kg = mass * ATOMIC_MASS_UNIT
-    distances, dx, dy = heavy.dist(
+    distances, dx, dy = dist(
         particles["xposition"], particles["yposition"], box_length
     )
     i, j = np.triu_indices(particles.size, 1)
@@ -48,8 +47,8 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     upper = np.maximum(types[i], types[j])
     forces = np.zeros(distances.size)
     energies = np.zeros(distances.size)
-    # '0,1' and '1,0' are the same pair of types, so evaluate each unordered
-    # pair once, on only the distances belonging to it.
+    # A pair of types 0 and 1 is the same pair as 1 and 0, so evaluate each
+    # unordered pair once, on only the distances belonging to it.
     for type_1, type_2 in sorted(set(zip(lower.tolist(), upper.tolist(), strict=True))):
         mask = (lower == type_1) & (upper == type_2)
         ff = forcefield(np.array(constants[type_1]))
@@ -64,22 +63,28 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
 
 
 def update_accelerations(particles, f, m, dx, dy, dr):
-    """Set the accelerations on each particle from the pair forces.
+    """Add the accelerations from the pair forces to each particle.
+
+    The accelerations already on the particles are added to, so the caller
+    zeroes them first. The pair arrays are in i < j order, as returned by
+    dist.
 
     Parameters
     ----------
     particles: util.particle_dt, array_like
         Information about the particles.
     f: float, array_like
-        The force on each pair of particles.
+        The force on each pair of particles, in Newtons.
     m: float
         Mass of the particles, in kilograms.
     dx: float, array_like
-        The x-dimension component of each pair separation.
+        The x-dimension component of each pair separation, x_i - x_j, in
+        metres.
     dy: float, array_like
-        The y-dimension component of each pair separation.
+        The y-dimension component of each pair separation, y_i - y_j, in
+        metres.
     dr: float, array_like
-        The distance between each pair of particles.
+        The distance between each pair of particles, in metres.
 
     Returns
     -------
@@ -101,10 +106,10 @@ def calculate_pressure(
     distances, forces, box_length, number_of_particles, temperature
 ):
     r"""Calculate the instantaneous pressure of the simulation cell in two
-    dimensions, from the pair forces already computed for the configuration:
+    dimensions, from the pair distances and forces of the configuration:
 
     .. math::
-        p = \frac{N k_B T}{L^2} + \frac{1}{2 L^2} \sum_{i} \sum_{j < i}
+        p = \frac{N k_B T}{L^2} + \frac{1}{2 L^2} \sum_{i} \sum_{j > i}
         r_{ij} f_{ij}
 
     Parameters
@@ -137,20 +142,23 @@ def dist(xposition, yposition, box_length):
     Parameters
     ----------
     xposition: float, array_like (N)
-        The x-dimension positions of the N particles.
+        The x-dimension positions of the N particles, in metres.
     yposition: float, array_like (N)
-        The y-dimension positions of the N particles.
+        The y-dimension positions of the N particles, in metres.
     box_length: float
-        The box length of the simulation cell.
+        The box length of the simulation cell, in metres.
 
     Returns
     -------
     dr: float, array_like (N (N - 1) / 2)
-        The distance between each pair of particles, in i < j pair order.
+        The distance between each pair of particles, in metres, in i < j pair
+        order.
     dx: float, array_like (N (N - 1) / 2)
-        The x-dimension component of each pair separation.
+        The x-dimension component of each pair separation, x_i - x_j, in
+        metres.
     dy: float, array_like (N (N - 1) / 2)
-        The y-dimension component of each pair separation.
+        The y-dimension component of each pair separation, y_i - y_j, in
+        metres.
     """
     i, j = np.triu_indices(xposition.size, 1)
     dx = xposition[i] - xposition[j]

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -97,60 +97,6 @@ def update_accelerations(particles, f, m, dx, dy, dr):
     return particles
 
 
-def lennard_jones_energy(A, B, dr):
-    """pairwise.lennard_jones_energy has been deprecated, please use
-    forcefields.lennard_jones instead
-
-    Calculate the energy of a pair of particles at a given distance.
-
-    Parameters
-    ----------
-    A: float
-        The value of the A parameter for the Lennard-Jones potential.
-    B: float
-        The value of the B parameter for the Lennard-Jones potential.
-    dr: float
-        The distance between the two particles.
-
-    Returns
-    -------
-    float:
-        The potential energy between the two particles.
-    """
-    print(
-        "pairwise.lennard_jones_energy has been deprecated, please use "
-        "forcefields.lennard_jones instead"
-    )
-    return A * np.power(dr, -12) - B * np.power(dr, -6)
-
-
-def lennard_jones_force(A, B, dr):
-    """pairwise.lennard_jones_energy has been deprecated, please use
-    forcefields.lennard_jones with force=True instead
-
-    Calculate the force between a pair of particles at a given distance.
-
-    Parameters
-    ----------
-    A: float
-        The value of the A parameter for the Lennard-Jones potential.
-    B: float
-        The value of the B parameter for the Lennard-Jones potential.
-    dr: float
-        The distance between the two particles.
-
-    Returns
-    -------
-    float:
-        The force between the two particles.
-    """
-    print(
-        "pairwise.lennard_jones_energy has been deprecated, please use "
-        "forcefields.lennard_jones with force=True instead"
-    )
-    return 12 * A * np.power(dr, -13) - 6 * B * np.power(dr, -7)
-
-
 def calculate_pressure(
     distances, forces, box_length, number_of_particles, temperature
 ):

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -38,103 +38,63 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     """
     particles["xacceleration"] = np.zeros(particles["xacceleration"].size)
     particles["yacceleration"] = np.zeros(particles["yacceleration"].size)
-    mass_amu = mass  # amu
-    mass_kg = mass_amu * ATOMIC_MASS_UNIT  # kilograms
-    distances, dx, dy, pair_types = heavy.dist(
-        particles["xposition"], particles["yposition"], box_length, particles['types']
+    mass_kg = mass * ATOMIC_MASS_UNIT
+    distances, dx, dy = heavy.dist(
+        particles["xposition"], particles["yposition"], box_length
     )
-    forces = np.zeros(len(distances))
-    energies = np.zeros(len(distances))
+    i, j = np.triu_indices(particles.size, 1)
+    types = np.array(particles["types"], dtype=int)
+    lower = np.minimum(types[i], types[j])
+    upper = np.maximum(types[i], types[j])
+    forces = np.zeros(distances.size)
+    energies = np.zeros(distances.size)
     # '0,1' and '1,0' are the same pair of types, so evaluate each unordered
     # pair once, on only the distances belonging to it.
-    canonical_pairs = np.array(
-        [",".join(sorted(pair.split(","), key=int)) for pair in pair_types]
-    )
-    for pair in sorted(set(canonical_pairs)):
-        mask = canonical_pairs == pair
-        type_1, type_2 = pair.split(",")
-        ff = forcefield(np.array(constants[int(type_1)]))
+    for type_1, type_2 in sorted(set(zip(lower.tolist(), upper.tolist(), strict=True))):
+        mask = (lower == type_1) & (upper == type_2)
+        ff = forcefield(np.array(constants[type_1]))
         if type_1 != type_2:
-            ff.mixing(np.array(constants[int(type_2)]))
+            ff.mixing(np.array(constants[type_2]))
         forces[mask] = ff.force(distances[mask])
         energies[mask] = ff.energy(distances[mask])
-    forces[np.where(distances > cut_off)] = 0.0
-    energies[np.where(distances > cut_off)] = 0.0
+    forces[distances > cut_off] = 0.0
+    energies[distances > cut_off] = 0.0
     particles = update_accelerations(particles, forces, mass_kg, dx, dy, distances)
     return particles, distances, forces, energies
 
-def separation(dx, dy):
-    """Calculate the distance in 2D space.
-
-    Parameters
-    ----------
-    dx: float
-        Vector in the x dimension
-    dy: float
-        Vector in the y dimension
-    Returns
-    float:
-        Magnitude of the 2D vector.
-    """
-    return np.sqrt(dx * dx + dy * dy)
-
 
 def update_accelerations(particles, f, m, dx, dy, dr):
-    """Update the acceleration arrays of particles.
+    """Set the accelerations on each particle from the pair forces.
 
     Parameters
     ----------
     particles: util.particle_dt, array_like
         Information about the particles.
-    f: float
-        The force on the pair of particles.
+    f: float, array_like
+        The force on each pair of particles.
     m: float
-        Mass of the particles.
-    dx: float
-        Distance between the particles in the x dimension.
-    dy: float
-        Distance between the particles in the y dimension.
-    dr: float
-        Distance between the particles.
+        Mass of the particles, in kilograms.
+    dx: float, array_like
+        The x-dimension component of each pair separation.
+    dy: float, array_like
+        The y-dimension component of each pair separation.
+    dr: float, array_like
+        The distance between each pair of particles.
+
     Returns
     -------
     util.particle_dt, array_like
-        Information about the particles with updated accelerations.
+        The particles with their accelerations accumulated from the pairs.
     """
-    k = 0
-    for i in range(0, particles.size - 1):
-        for j in range(i + 1, particles.size):
-
-            particles["xacceleration"][i] += second_law(f[k], m, dx[k], dr[k]) if f[k]!=0 else 0
-            particles["yacceleration"][i] += second_law(f[k], m, dy[k], dr[k]) if f[k]!=0 else 0
-            
-            particles["xacceleration"][j] -= second_law(f[k], m, dx[k], dr[k]) if f[k]!=0 else 0
-            particles["yacceleration"][j] -= second_law(f[k], m, dy[k], dr[k]) if f[k]!=0 else 0
-            k += 1
-        
+    i, j = np.triu_indices(particles.size, 1)
+    ax = f * dx / dr / m
+    ay = f * dy / dr / m
+    # each pair accelerates particle i one way and particle j the other.
+    np.add.at(particles["xacceleration"], i, ax)
+    np.add.at(particles["xacceleration"], j, -ax)
+    np.add.at(particles["yacceleration"], i, ay)
+    np.add.at(particles["yacceleration"], j, -ay)
     return particles
-
-
-def second_law(f, m, d1, d2):
-    """Newton's second law of motion to get the acceleration of the particle
-    in a given dimension.
-
-    Parameters
-    ----------
-    f: float
-        The force on the pair of particles.
-    m: float
-        Mass of the particle.
-    d1: float
-        Distance between the particles in a single dimension.
-    d2: float
-        Distance between the particles across all dimensions.
-    Returns
-    -------
-    float:
-        Acceleration of the particle in a given dimension.
-    """
-    return (f * d1 / d2) / m
 
 
 def lennard_jones_energy(A, B, dr):
@@ -237,69 +197,31 @@ def calculate_pressure(
     return pres
 
 
-def dist(xposition, yposition, box_length, types):
-    """Returns the distance array for the set of particles.
+def dist(xposition, yposition, box_length):
+    """Return the minimum-image distances between every pair of particles.
 
     Parameters
     ----------
-    xpos: float, array_like (N)
-        Array of length N, where N is the number of particles, providing the
-        x-dimension positions of the particles.
-    ypos: float, array_like (N)
-        Array of length N, where N is the number of particles, providing the
-        y-dimension positions of the particles.
+    xposition: float, array_like (N)
+        The x-dimension positions of the N particles.
+    yposition: float, array_like (N)
+        The y-dimension positions of the N particles.
     box_length: float
         The box length of the simulation cell.
-    types: str, array_like (N)
-        Array of length N, where N is the number of particles, providing the
-        type of each particle.
 
     Returns
     -------
-    drr: float, array_like ((N - 1) * N / 2))
-        The pairs of distances between the particles.
-    dxr: float, array_like ((N - 1) * N / 2))
-        The pairs of distances between the particles, in only the x-dimension.
-    dyr: float, array_like ((N - 1) * N / 2))
-        The pairs of distances between the particles, in only the y-dimension.
-    pair_types: str, array_like ((N - 1) * N / 2))
-        The types of the two particles in each interaction, saved as 
-        'type1,type2' for each
+    dr: float, array_like (N (N - 1) / 2)
+        The distance between each pair of particles, in i < j pair order.
+    dx: float, array_like (N (N - 1) / 2)
+        The x-dimension component of each pair separation.
+    dy: float, array_like (N (N - 1) / 2)
+        The y-dimension component of each pair separation.
     """
-    drr = np.zeros(int((xposition.size - 1) * xposition.size / 2))
-    dxr = np.zeros(int((xposition.size - 1) * xposition.size / 2))
-    dyr = np.zeros(int((xposition.size - 1) * xposition.size / 2))
-    pair_types = []
-    k = 0
-    for i in range(0, xposition.size - 1):
-        for j in range(i + 1, xposition.size):
-            dx = xposition[i] - xposition[j]
-            dy = yposition[i] - yposition[j]
-            dx = pbc_correction(dx, box_length)
-            dy = pbc_correction(dy, box_length)
-            dr = separation(dx, dy)
-            drr[k] = dr
-            dxr[k] = dx
-            dyr[k] = dy
-            pair_types.append(types[i] + ',' + types[j])
-            k += 1
-    return drr, dxr, dyr, pair_types
-
-
-def pbc_correction(position, cell):
-    """Correct for the periodic boundary condition.
-
-    Parameters
-    ----------
-    position: float
-        Particle position.
-    cell: float
-        Cell vector.
-
-    Returns
-    -------
-    float:
-        Corrected particle position."""
-    if np.abs(position) > 0.5 * cell:
-        position *= 1 - cell / np.abs(position)
-    return position
+    i, j = np.triu_indices(xposition.size, 1)
+    dx = xposition[i] - xposition[j]
+    dy = yposition[i] - yposition[j]
+    dx -= box_length * np.round(dx / box_length)
+    dy -= box_length * np.round(dy / box_length)
+    dr = np.hypot(dx, dy)
+    return dr, dx, dy

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -177,7 +177,8 @@ def calculate_pressure(
     Returns
     -------
     float:
-        Instantaneous pressure of the simulation.
+        Instantaneous pressure of the simulation, in N / m (a two-dimensional
+        pressure).
     """
     virial = np.sum(forces * distances) / (2 * box_length * box_length)
     ideal = number_of_particles * BOLTZMANN * temperature / (box_length * box_length)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -58,6 +58,11 @@ class TestMd(unittest.TestCase):
     def test_sample_pressure_uses_the_stored_pair_forces(self):
         system = md.initialise(20, 300, 20, "square")
         system.integrate(md.velocity_verlet)
+        # Sentinels the force loop would never produce: the sampled pressure
+        # reflects them only if sample reuses the stored data instead of
+        # recomputing it from the particle positions.
+        system.distances = np.full_like(system.distances, 3e-10)
+        system.forces = np.full_like(system.forces, 1e-12)
         system.md_sample()
         temperature = md.calculate_temperature(system.particles, system.mass)
         expected = pairwise.calculate_pressure(

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import forcefields as ff
-from pylj import md
+from pylj import md, pairwise
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
 
 
@@ -54,6 +54,20 @@ class TestMd(unittest.TestCase):
         a.md_sample()
         assert_equal(a.step_sample, [3, 7])
         assert_equal(a.energy_sample.size, 2)
+
+    def test_sample_pressure_uses_the_stored_pair_forces(self):
+        system = md.initialise(20, 300, 20, "square")
+        system.integrate(md.velocity_verlet)
+        system.md_sample()
+        temperature = md.calculate_temperature(system.particles, system.mass)
+        expected = pairwise.calculate_pressure(
+            system.distances,
+            system.forces,
+            system.box_length,
+            system.particles.size,
+            temperature,
+        )
+        assert_almost_equal(system.pressure_sample[-1], expected)
 
     def test_velocity_verlet(self):
         a = md.initialise(2, 300, 8, "square")

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -58,7 +58,7 @@ class TestMd(unittest.TestCase):
     def test_sample_pressure_uses_the_stored_pair_forces(self):
         system = md.initialise(20, 300, 20, "square")
         system.integrate(md.velocity_verlet)
-        # Sentinels the force loop would never produce: the sampled pressure
+        # Sentinels no force evaluation would produce: the sampled pressure
         # reflects them only if sample reuses the stored data instead of
         # recomputing it from the particle positions.
         system.distances = np.full_like(system.distances, 3e-10)

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -43,19 +43,21 @@ class gaussian_core:
 
 class TestPairwise(unittest.TestCase):
     def test_update_accelerations(self):
+        # Three particles, so particle 0 receives two contributions and the
+        # per-pair contributions must be accumulated, not assigned.
         part_dt = util.particle_dt()
-        particles = np.zeros(2, dtype=part_dt)
-        ones = np.array([1])
-        dist = np.array([np.sqrt(2)])
-        particles = pairwise.update_accelerations(particles, ones, 1, ones, ones, dist)
-        assert_almost_equal(particles["xacceleration"][0], 0.707106781)
-        assert_almost_equal(particles["yacceleration"][0], 0.707106781)
-        assert_almost_equal(particles["xacceleration"][1], -0.707106781)
-        assert_almost_equal(particles["yacceleration"][1], -0.707106781)
+        particles = np.zeros(3, dtype=part_dt)
+        # pairs (0, 1), (0, 2), (1, 2)
+        forces = np.array([1.0, 2.0, 3.0])
+        dx = np.array([1.0, 0.0, 1.0])
+        dy = np.array([0.0, 1.0, 0.0])
+        dr = np.array([1.0, 1.0, 1.0])
+        particles = pairwise.update_accelerations(particles, forces, 2.0, dx, dy, dr)
+        assert_almost_equal(particles["xacceleration"], [0.5, -0.5 + 1.5, -1.5])
+        assert_almost_equal(particles["yacceleration"], [1.0, 0.0, -1.0])
 
     def test_calculate_pressure(self):
-        # The virial sum(f r) / (2 L^2) plus the ideal term N k_B T / L^2, from
-        # pair data passed in directly.
+        # The virial sum(f r) / (2 L^2) plus the ideal term N k_B T / L^2.
         distances = np.array([4e-10])
         forces = np.array([-9.5864009e-12])
         p = pairwise.calculate_pressure(
@@ -70,15 +72,16 @@ class TestPairwise(unittest.TestCase):
         assert_almost_equal(p, virial + ideal)
 
     def test_dist_applies_the_minimum_image(self):
-        # Two particles 1 Angstrom apart across the periodic boundary of a
-        # 10 Angstrom box: the minimum image is 1 Angstrom, not the 9 Angstrom
-        # raw separation.
-        xposition = np.array([0.5e-10, 9.5e-10])
-        yposition = np.array([0.0, 0.0])
+        # Pairs 1 Angstrom apart across the periodic boundary of a 10 Angstrom
+        # box: the minimum image is 1 Angstrom, not the 9 Angstrom raw
+        # separation, on either axis and in either direction. Pairs are
+        # (0, 1), (0, 2), (1, 2) and components are x_i - x_j.
+        xposition = np.array([0.5e-10, 9.5e-10, 0.5e-10])
+        yposition = np.array([9.5e-10, 9.5e-10, 0.5e-10])
         dr, dx, dy = pairwise.dist(xposition, yposition, 10e-10)
-        assert_almost_equal(dr * 1e10, [1.0])
-        assert_almost_equal(dx * 1e10, [1.0])
-        assert_almost_equal(dy * 1e10, [0.0])
+        assert_almost_equal(dr * 1e10, [1.0, 1.0, np.sqrt(2)])
+        assert_almost_equal(dx * 1e10, [1.0, 0.0, -1.0])
+        assert_almost_equal(dy * 1e10, [0.0, -1.0, -1.0])
 
     def test_compute_force_zeroes_pairs_beyond_the_cut_off(self):
         # cut_off is compared against the pair distances directly, so it is in
@@ -161,8 +164,7 @@ class TestPairwise(unittest.TestCase):
     def test_compute_force_matches_a_reference_loop(self):
         # An independent double loop over pairs is the oracle for the pairwise
         # distances, energies, forces and accelerations. Full-box positions
-        # exercise the minimum image. cut_off is large so no pair is zeroed,
-        # keeping the oracle to the pair maths that the other tests do not pin.
+        # exercise the minimum image. cut_off is large so no pair is zeroed.
         rng = np.random.default_rng(0)
         n = 8
         box_length = 30e-10

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_almost_equal
 
 from pylj import forcefields as ff
 from pylj import pairwise, util
+from pylj.constants import ATOMIC_MASS_UNIT
 
 
 class gaussian_core:
@@ -223,3 +224,61 @@ class TestPairwise(unittest.TestCase):
             expected_forces.append(forcefield.force(distance))
         assert_almost_equal(energies, expected_energies)
         assert_almost_equal(forces, expected_forces)
+
+    def test_compute_force_matches_a_reference_loop(self):
+        # An independent double loop over pairs is the oracle for the pairwise
+        # distances, energies, forces and accelerations. Full-box positions
+        # exercise the minimum image. cut_off is large so no pair is zeroed,
+        # keeping the oracle to the pair maths that the other tests do not pin.
+        rng = np.random.default_rng(0)
+        n = 8
+        box_length = 30e-10
+        part_dt = util.particle_dt()
+        particles = np.zeros(n, dtype=part_dt)
+        particles["xposition"] = rng.uniform(0, box_length, n)
+        particles["yposition"] = rng.uniform(0, box_length, n)
+        types = ["0", "0", "1", "1", "0", "1", "0", "1"]
+        particles["types"] = types
+        constants = [[1.363e-134, 9.273e-78], [1.5e-134, 1.1e-77]]
+        mass = 39.948
+        cut_off = 1e-8
+        mass_kg = mass * ATOMIC_MASS_UNIT
+
+        ref_dr, ref_energy, ref_force = [], [], []
+        ref_ax = np.zeros(n)
+        ref_ay = np.zeros(n)
+        for a in range(n - 1):
+            for b in range(a + 1, n):
+                dx = particles["xposition"][a] - particles["xposition"][b]
+                dy = particles["yposition"][a] - particles["yposition"][b]
+                dx -= box_length * np.round(dx / box_length)
+                dy -= box_length * np.round(dy / box_length)
+                dr = np.hypot(dx, dy)
+                low, high = sorted((int(types[a]), int(types[b])))
+                pair = ff.lennard_jones(np.array(constants[low]))
+                if low != high:
+                    pair.mixing(np.array(constants[high]))
+                force = pair.force(dr)
+                ref_dr.append(dr)
+                ref_energy.append(pair.energy(dr))
+                ref_force.append(force)
+                ax = force * dx / dr / mass_kg
+                ay = force * dy / dr / mass_kg
+                ref_ax[a] += ax
+                ref_ax[b] -= ax
+                ref_ay[a] += ay
+                ref_ay[b] -= ay
+
+        particles, distances, forces, energies = pairwise.compute_force(
+            particles,
+            box_length,
+            cut_off,
+            constants=constants,
+            forcefield=ff.lennard_jones,
+            mass=mass,
+        )
+        np.testing.assert_allclose(distances, ref_dr, rtol=1e-12)
+        np.testing.assert_allclose(energies, ref_energy, rtol=1e-12)
+        np.testing.assert_allclose(forces, ref_force, rtol=1e-12)
+        np.testing.assert_allclose(particles["xacceleration"], ref_ax, rtol=1e-12)
+        np.testing.assert_allclose(particles["yacceleration"], ref_ay, rtol=1e-12)

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -54,25 +54,20 @@ class TestPairwise(unittest.TestCase):
         assert_almost_equal(particles["yacceleration"][1], -0.707106781)
 
     def test_calculate_pressure(self):
-        part_dt = util.particle_dt()
-        particles = np.zeros(2, dtype=part_dt)
-        particles["xposition"][0] = 1e-10
-        particles["xposition"][1] = 5e-10
-        particles['types'] = ['0','0']
+        # The virial sum(f r) / (2 L^2) plus the ideal term N k_B T / L^2, from
+        # pair data passed in directly.
+        distances = np.array([4e-10])
+        forces = np.array([-9.5864009e-12])
         p = pairwise.calculate_pressure(
-            particles,
-            30,
+            distances,
+            forces,
+            30e-10,
+            2,
             300,
-            15,
-            constants=[[1.363e-134, 9.273e-78]],
-            forcefield=ff.lennard_jones,
-            mass = 39.948
         )
-        # Only the ideal-gas term N k_B T / L^2 depends on the Boltzmann
-        # constant. Moving from 1.3806e-23 to the CODATA 1.380649e-23 raises
-        # it by 3.267e-28 Pa, which is the whole of the change from the
-        # previous expectation of 7.07368867.
-        assert_almost_equal(p * 1e24, 7.07401534)
+        virial = np.sum(forces * distances) / (2 * (30e-10) ** 2)
+        ideal = 2 * 1.380649e-23 * 300 / (30e-10) ** 2
+        assert_almost_equal(p, virial + ideal)
 
     def test_dist_applies_the_minimum_image(self):
         # Two particles 1 Angstrom apart across the periodic boundary of a

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -53,35 +53,6 @@ class TestPairwise(unittest.TestCase):
         assert_almost_equal(particles["xacceleration"][1], -0.707106781)
         assert_almost_equal(particles["yacceleration"][1], -0.707106781)
 
-    def test_second_law(self):
-        a = pairwise.second_law(1, 1, 1, np.sqrt(2))
-        assert_almost_equal(a, 0.707106781)
-
-    def test_separation(self):
-        a = pairwise.separation(1, 1)
-        assert_almost_equal(a, np.sqrt(2))
-
-    def test_compute_forces(self):
-        part_dt = util.particle_dt()
-        particles = np.zeros(2, dtype=part_dt)
-        particles["xposition"][0] = 1e-10
-        particles["xposition"][1] = 5e-10
-        particles['types'] = ['0','0']
-        particles, distances, forces, energies = pairwise.compute_force(
-            particles,
-            30,
-            15,
-            constants=[[1.363e-134, 9.273e-78]],
-            forcefield=ff.lennard_jones,
-            mass=39.948
-        )
-        assert_almost_equal(distances, [4e-10])
-        assert_almost_equal(energies, [-1.4515047e-21])
-        assert_almost_equal(forces, [-9.5864009e-12])
-        assert_almost_equal(particles["yacceleration"], [0, 0])
-        assert_almost_equal(particles["xacceleration"][0] / 1e14, 1.4451452)
-        assert_almost_equal(particles["xacceleration"][1] / 1e14, -1.4451452)
-
     def test_calculate_pressure(self):
         part_dt = util.particle_dt()
         particles = np.zeros(2, dtype=part_dt)
@@ -102,50 +73,6 @@ class TestPairwise(unittest.TestCase):
         # it by 3.267e-28 Pa, which is the whole of the change from the
         # previous expectation of 7.07368867.
         assert_almost_equal(p * 1e24, 7.07401534)
-
-    def test_pbc_correction(self):
-        a = pairwise.pbc_correction(1, 10)
-        assert_almost_equal(a, 1)
-        b = pairwise.pbc_correction(11, 10)
-        assert_almost_equal(b, 1)
-    
-    def test_multiple_particles(self):
-        part_dt = util.particle_dt()
-        particles = np.zeros(3, dtype=part_dt)
-        particles["xposition"][0] = 1e-10
-        particles["xposition"][1] = 5e-10
-        particles["yposition"][2] = 5e-10
-        particles['types'] = ['0','1','0']
-        constants = [[1.363e-134, 9.273e-78], [1.363e-133, 9.273e-77]]
-        particles, distances, forces, energies = pairwise.compute_force(
-            particles,
-            30,
-            15,
-            constants=constants,
-            forcefield=ff.lennard_jones,
-            mass=39.948
-        )
-        assert_almost_equal(distances, [4.0000000e-10, 5.0990195e-10, 7.0710678e-10])
-        # Each pair contributes its energy once, evaluated with the forcefield
-        # for its own pair of types. Particles 0 and 2 are type 0 and particle
-        # 1 is type 1, so the pairs are (0, 1), (0, 0) and (1, 0) in the order
-        # the distances come back. Unlike pairs mix the two sets of constants,
-        # as compute_force does.
-        expected = []
-        for distance, pair in zip(distances, [(0, 1), (0, 0), (1, 0)], strict=True):
-            forcefield = ff.lennard_jones(constants[pair[0]])
-            if pair[0] != pair[1]:
-                forcefield.mixing(constants[pair[1]])
-            expected.append(forcefield.energy(distance))
-        assert_almost_equal(np.array(energies) * 1e20, np.array(expected) * 1e20)
-        assert_almost_equal(forces, [-9.6342138e-11, -5.1698213e-12, -6.1773405e-12])
-        assert_almost_equal(particles["yacceleration"],
-                            [7.6421357e+13, 2.07196175e+13, -9.71409740e+13],
-                            decimal=-7)
-        # The accelerations go as 1 / mass, so they shift by 42 parts in 1e9
-        # with the CODATA atomic mass unit, from 4.4171075 and -4.7771464.
-        assert_almost_equal(particles["xacceleration"][0] / 1e14, 4.4171073)
-        assert_almost_equal(particles["xacceleration"][1] / 1e14, -4.7771462)
 
     def test_compute_force_zeroes_pairs_beyond_the_cut_off(self):
         # cut_off is compared against the pair distances directly, so it is in

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -74,6 +74,17 @@ class TestPairwise(unittest.TestCase):
         # previous expectation of 7.07368867.
         assert_almost_equal(p * 1e24, 7.07401534)
 
+    def test_dist_applies_the_minimum_image(self):
+        # Two particles 1 Angstrom apart across the periodic boundary of a
+        # 10 Angstrom box: the minimum image is 1 Angstrom, not the 9 Angstrom
+        # raw separation.
+        xposition = np.array([0.5e-10, 9.5e-10])
+        yposition = np.array([0.0, 0.0])
+        dr, dx, dy = pairwise.dist(xposition, yposition, 10e-10)
+        assert_almost_equal(dr * 1e10, [1.0])
+        assert_almost_equal(dx * 1e10, [1.0])
+        assert_almost_equal(dy * 1e10, [0.0])
+
     def test_compute_force_zeroes_pairs_beyond_the_cut_off(self):
         # cut_off is compared against the pair distances directly, so it is in
         # the same units as the positions (metres here). At 6e-10 m it sits

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -23,7 +23,7 @@ class System:
     number_of_particles: int
         Number of particles to simulate.
     temperature: float
-        Initial temperature of the particles, in Kelvin.
+        Initial temperature of the particles, in kelvin.
     box_length: float
         Length of a single dimension of the simulation square, in
         Angstrom.
@@ -447,7 +447,7 @@ class System:
         """Rescale the particle velocities to the bath temperature.
 
         Args:
-            bath_temperature: The desired temperature, in Kelvin.
+            bath_temperature: The desired temperature, in kelvin.
 
         Raises:
             ValueError: If the bath temperature is not positive, or the


### PR DESCRIPTION
## Summary

Vectorises the pairwise hot paths and stops pressure sampling recomputing the forces, without changing any physics.

- `pairwise.dist` and `update_accelerations` are vectorised with NumPy: pair indices from `np.triu_indices`, the minimum image from `np.round`, distances from `np.hypot`, and acceleration accumulation with `np.add.at`.
- `compute_force` derives integer type pairs and evaluates each forcefield only on the distances of its own pairs.
- `calculate_pressure` is now a pure function of the pair data, `(distances, forces, box_length, number_of_particles, temperature)`. `md.sample` feeds it the forces and distances stored by the last force evaluation, so a sampled step no longer repeats the whole pair loop.
- Removes the now-dead helpers `separation`, `pbc_correction` and `second_law`, and the deprecated `lennard_jones_energy` and `lennard_jones_force` wrappers. The intro notebook, which named `lennard_jones_energy`, now points at the `energy` method of `forcefields.lennard_jones`.
- Corrects the internal `box_length` docstrings, which said Angstrom although the library works in metres internally, and a subject-verb slip in the cut-off description, for the functions touched here. The wider docstring clarity pass is tracked in #58.

Correctness is pinned by an independent double-loop reference test that reproduces distances, energies, forces and accelerations to a relative tolerance of 1e-12, alongside tests for the minimum image, the cut-off masking, per-type evaluation, and that `md.sample` reuses the stored forces rather than recomputing them.

## Performance

Integrate and sample per step, argon on a square lattice:

- N = 100: 41.5 ms to 1.1 ms
- N = 400: 616 ms to 11.6 ms

## API changes

- `pairwise.dist(xposition, yposition, box_length)` returns `(dr, dx, dy)` and no longer takes or returns particle types.
- `pairwise.calculate_pressure(distances, forces, box_length, number_of_particles, temperature)`.
- Removed `pairwise.separation`, `pairwise.pbc_correction`, `pairwise.second_law`, `pairwise.lennard_jones_energy` and `pairwise.lennard_jones_force`.

Resolves #77. Closes #50.

