### PR TITLE
Keep unwrapped positions for the MSD and add System.restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to pylj are recorded here. The format follows
 - `System.cores`, the separation at which each forcefield's pair energy falls to zero, found numerically from its `energy` method. Initial configurations keep particles at least this far apart.
 - `pylj.constants`, taking the Boltzmann constant and the atomic mass unit from `scipy.constants`.
 - ruff and mypy configuration in `pyproject.toml`, a `dev` extra, and continuous integration on Python 3.11 to 3.14.
+- `System.restart()` returns a new system that continues from the current configuration with step and time at zero, empty sample arrays and the mean squared displacement measured from the copied positions, for starting a production run after equilibration.
 
 ### Changed
 
@@ -29,6 +30,7 @@ All notable changes to pylj are recorded here. The format follows
 - `energy` and `force` on the forcefields return a Python float for scalar input, rather than `np.float64`; a one-element list, such as to `square_well.energy`, returns a one-element array rather than a float.
 - `pairwise.compute_force` evaluates each forcefield only on the pairs of its own types, instead of passing every forcefield the full distance array with the other types' entries zeroed.
 - Pair distances and accelerations are computed with vectorised NumPy. `pairwise.dist` returns `(dr, dx, dy)` and no longer takes or returns particle types; `pairwise.calculate_pressure` takes the pair distances and forces directly, `(distances, forces, box_length, number_of_particles, temperature)`, and `md.sample` feeds it the forces stored by the last force evaluation rather than recomputing them.
+- The particle dtype carries `xunwrapped` and `yunwrapped`, positions without periodic wrapping, advanced by `md.velocity_verlet`; `xprevious_position`, `yprevious_position`, `xpbccount` and `ypbccount` are gone. `md.calculate_msd(particles, initial_particles)` reads the unwrapped positions and no longer takes `box_length`; `md.update_positions` takes and returns the unwrapped positions in place of the previous positions.
 
 ### Fixed
 
@@ -44,6 +46,7 @@ All notable changes to pylj are recorded here. The format follows
 - A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units) is refused with a clear message.
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
+- The mean squared displacement was wrong unless sampled on every integration step, and non-zero before the first step (#74).
 
 ### Removed
 

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -36,7 +36,7 @@ def initialise(
     constants: float, array_like (optional)
         The values of the constants for the forcefield used. Defaults to the
         argon Lennard-Jones constants, ``[[1.363e-134, 9.273e-78]]``.
-    forcefield: function (optional)
+    forcefield: class (optional)
         The particular forcefield to be used to find the energy and forces.
     diameter: float or iterable of float (optional)
         Drawn diameter of the particles in Angstrom, one value or one per

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -177,7 +177,7 @@ def sample(particles, box_length, initial_particles, system):
         particles.size,
         temperature_new,
     )
-    msd_new = calculate_msd(particles, initial_particles, box_length)
+    msd_new = calculate_msd(particles, initial_particles)
     system.pressure_sample = np.append(system.pressure_sample, pressure_new)
     system.force_sample = np.append(system.force_sample, np.sum(system.forces))
     system.energy_sample = np.append(system.energy_sample, np.sum(system.energies))
@@ -186,44 +186,26 @@ def sample(particles, box_length, initial_particles, system):
     return system
 
 
-def calculate_msd(particles, initial_particles, box_length):
-    """Determines the mean squared displacement of the particles in the system.
+def calculate_msd(particles, initial_particles):
+    """Determines the mean squared displacement of the particles from their
+    positions in initial_particles, using the unwrapped positions so that
+    crossings of the periodic boundary are counted at any sampling cadence.
 
     Parameters
     ----------
     particles: util.particle_dt, array_like
         Information about the particles.
     initial_particles: util.particle_dt, array_like
-        Information about the initial state of the particles.
-    box_length: float
-        Size of the cell vector.
+        Information about the particles at the origin of the displacement.
 
     Returns
     -------
     float:
-        Mean squared deviation for the particles at the given timestep.
+        Mean squared displacement of the particles, in metres squared.
     """
-    xpos = np.array(particles["xposition"])
-    ypos = np.array(particles["yposition"])
-    dxinst = xpos - particles["xprevious_position"]
-    dyinst = ypos - particles["yprevious_position"]
-    for i in range(0, particles["xposition"].size):
-        if np.abs(dxinst[i]) > 0.5 * box_length:
-            if xpos[i] <= 0.5 * box_length:
-                particles["xpbccount"][i] += 1
-            if xpos[i] > 0.5 * box_length:
-                particles["xpbccount"][i] -= 1
-        xpos[i] += box_length * particles["xpbccount"][i]
-        if np.abs(dyinst[i]) > 0.5 * box_length:
-            if ypos[i] <= 0.5 * box_length:
-                particles["ypbccount"][i] += 1
-            if ypos[i] > 0.5 * box_length:
-                particles["ypbccount"][i] -= 1
-        ypos[i] += box_length * particles["ypbccount"][i]
-    dx = xpos - initial_particles["xposition"]
-    dy = ypos - initial_particles["yposition"]
-    dr = np.sqrt(dx * dx + dy * dy)
-    return np.average(dr ** 2)
+    dx = particles["xunwrapped"] - initial_particles["xunwrapped"]
+    dy = particles["yunwrapped"] - initial_particles["yunwrapped"]
+    return np.mean(dx * dx + dy * dy)
 
 
 def update_positions(

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -41,7 +41,7 @@ def initialise(
     constants: float, array_like (optional)
         The values of the constants for the forcefield used. Defaults to the
         argon Lennard-Jones constants, ``[[1.363e-134, 9.273e-78]]``.
-    forcefield: function (optional)
+    forcefield: class (optional)
         The particular forcefield to be used to find the energy and forces.
     diameter: float or iterable of float (optional)
         Drawn diameter of the particles in Angstrom, one value or one per
@@ -111,7 +111,8 @@ def velocity_verlet(
     Returns
     -------
     util.particle_dt, array_like:
-        Information about the particles, with new positions and velocities.
+        Information about the particles, with new positions, velocities and
+        accelerations.
     float, array_like
         Current distances between pairs of particles in the simulation.
     float, array_like
@@ -189,7 +190,10 @@ def sample(particles, box_length, initial_particles, system):
 def calculate_msd(particles, initial_particles):
     """Determines the mean squared displacement of the particles from their
     positions in initial_particles, using the unwrapped positions so that
-    crossings of the periodic boundary are included.
+    crossings of the periodic boundary are included. The unwrapped positions
+    are maintained by md.velocity_verlet only, so the displacement is
+    meaningful for a molecular dynamics system and not after Monte Carlo
+    moves.
 
     Parameters
     ----------

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -189,7 +189,7 @@ def sample(particles, box_length, initial_particles, system):
 def calculate_msd(particles, initial_particles):
     """Determines the mean squared displacement of the particles from their
     positions in initial_particles, using the unwrapped positions so that
-    crossings of the periodic boundary are counted at any sampling cadence.
+    crossings of the periodic boundary are included.
 
     Parameters
     ----------

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -188,8 +188,8 @@ def sample(particles, box_length, initial_particles, system):
 
 def calculate_msd(particles, initial_particles):
     """Determines the mean squared displacement of the particles from their
-    positions at the start of the simulation, using the unwrapped positions
-    so that crossings of the periodic boundary are included.
+    positions in initial_particles, using the unwrapped positions so that
+    crossings of the periodic boundary are included.
 
     Parameters
     ----------

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -188,8 +188,8 @@ def sample(particles, box_length, initial_particles, system):
 
 def calculate_msd(particles, initial_particles):
     """Determines the mean squared displacement of the particles from their
-    positions in initial_particles, using the unwrapped positions so that
-    crossings of the periodic boundary are included.
+    positions at the start of the simulation, using the unwrapped positions
+    so that crossings of the periodic boundary are included.
 
     Parameters
     ----------

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -86,10 +86,9 @@ initialize = initialise  # US spelling
 def velocity_verlet(
     particles, timestep_length, box_length, cut_off, constants, forcefield, mass
 ):
-    """Uses the Velocity-Verlet integrator to move forward in time. The
-    Updates the particles positions and velocities in terms of the Velocity
-    Verlet algorithm. Also calculates the instanteous temperature, pressure,
-    and force and appends these to the appropriate system array.
+    """Move the particles forward one step with the Velocity-Verlet
+    integrator: update the positions, recompute the forces, then update the
+    velocities from the mean of the old and new accelerations.
 
     Parameters
     ----------
@@ -99,24 +98,37 @@ def velocity_verlet(
         Length for each Velocity-Verlet integration step, in seconds.
     box_length: float
         Length of a single dimension of the simulation square, in metres.
+    cut_off: float
+        The separation beyond which the pair energy and force are taken to be
+        zero, in metres.
+    constants: float, array_like
+        The constants associated with the particular forcefield used.
+    forcefield: class
+        The particular forcefield to be used to find the energy and forces.
+    mass: float
+        The mass of the particle being simulated (units of atomic mass units).
 
     Returns
     -------
     util.particle_dt, array_like:
         Information about the particles, with new positions and velocities.
+    float, array_like
+        Current distances between pairs of particles in the simulation.
+    float, array_like
+        Current forces between pairs of particles in the simulation.
+    float, array_like
+        Current energies between pairs of particles in the simulation.
     """
-    xposition_store = list(particles["xposition"])
-    yposition_store = list(particles["yposition"])
-    pos, prev_pos = update_positions(
+    positions, unwrapped = update_positions(
         [particles["xposition"], particles["yposition"]],
-        [particles["xprevious_position"], particles["yprevious_position"]],
+        [particles["xunwrapped"], particles["yunwrapped"]],
         [particles["xvelocity"], particles["yvelocity"]],
         [particles["xacceleration"], particles["yacceleration"]],
         timestep_length,
         box_length,
     )
-    [particles["xposition"], particles["yposition"]] = pos
-    [particles["xprevious_position"], particles["yprevious_position"]] = pos
+    [particles["xposition"], particles["yposition"]] = positions
+    [particles["xunwrapped"], particles["yunwrapped"]] = unwrapped
     xacceleration_store = list(particles["xacceleration"])
     yacceleration_store = list(particles["yacceleration"])
     particles, distances, forces, energies = heavy.compute_force(
@@ -128,8 +140,6 @@ def velocity_verlet(
         [particles["xacceleration"], particles["yacceleration"]],
         timestep_length,
     )
-    particles["xprevious_position"] = xposition_store
-    particles["yprevious_position"] = yposition_store
     return particles, distances, forces, energies
 
 
@@ -217,7 +227,7 @@ def calculate_msd(particles, initial_particles, box_length):
 
 
 def update_positions(
-    positions, old_positions, velocities, accelerations, timestep_length, box_length
+    positions, unwrapped, velocities, accelerations, timestep_length, box_length
 ):
     """Update the particle positions using the Velocity-Verlet integrator.
 
@@ -225,17 +235,16 @@ def update_positions(
     ----------
     positions: (2, N) array_like
         Where N is the number of particles, and the first row are the x
-        positions and the second row the y positions.
-    old_positions: (2, N) array_like
-        Where N is the number of particles, and the first row are the
-        previous x positions and the second row are the y positions.
+        positions and the second row the y positions, wrapped into the
+        simulation cell.
+    unwrapped: (2, N) array_like
+        The same positions without periodic wrapping.
     velocities: (2, N) array_like
         Where N is the number of particles, and the first row are the x
         velocities and the second row the y velocities.
     accelerations: (2, N) array_like
         Where N is the number of particles, and the first row are the x
-        accelerations and the second row the y
-        accelerations.
+        accelerations and the second row the y accelerations.
     timestep_length: float
         Length for each Velocity-Verlet integration step, in seconds.
     box_length: float
@@ -244,19 +253,17 @@ def update_positions(
     Returns
     -------
     (2, N) array_like:
-        Updated positions.
+        Updated positions, wrapped into the simulation cell.
+    (2, N) array_like:
+        Updated unwrapped positions.
     """
-    old_positions[0] = np.array(positions[0])
-    old_positions[1] = np.array(positions[1])
-    positions[0] += (velocities[0] * timestep_length) + (
-        0.5 * accelerations[0] * timestep_length * timestep_length
-    )
-    positions[1] += (velocities[1] * timestep_length) + (
-        0.5 * accelerations[1] * timestep_length * timestep_length
-    )
-    positions[0] = positions[0] % box_length
-    positions[1] = positions[1] % box_length
-    return [positions[0], positions[1]], [old_positions[0], old_positions[1]]
+    for axis in (0, 1):
+        displacement = velocities[axis] * timestep_length + (
+            0.5 * accelerations[axis] * timestep_length * timestep_length
+        )
+        positions[axis] = (positions[axis] + displacement) % box_length
+        unwrapped[axis] = unwrapped[axis] + displacement
+    return [positions[0], positions[1]], [unwrapped[0], unwrapped[1]]
 
 
 def update_velocities(

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -322,7 +322,7 @@ def compute_force(particles, box_length, cut_off, constants, forcefield, mass):
     constants: float, array_like (optional)
         The constants associated with the particular forcefield used, e.g. for
         the function forcefields.lennard_jones, theses are [A, B]
-    forcefield: function (optional)
+    forcefield: class (optional)
         The particular forcefield to be used to find the energy and forces.
     mass: float (optional)
         The mass of the particle being simulated (units of atomic mass units).

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -141,18 +141,45 @@ class TestMd(unittest.TestCase):
         assert_almost_equal(b * 1e23, expected * 1e23)
 
     def test_calculate_msd(self):
+        # Displacements of (1, 1) and (5, 1) Angstrom from the origin
+        # positions give (2 + 26) / 2 = 14 Angstrom^2.
         a = md.initialise(2, 300, 8, "square")
-        a.particles["xposition"] = [3e-10, 3e-10]
-        a.particles["yposition"] = [3e-10, 7e-10]
-        b = md.calculate_msd(a.particles, a.initial_particles, a.box_length)
-        assert_almost_equal(b, 2e-20)
+        a.particles["xunwrapped"] = a.initial_particles["xunwrapped"] + [1e-10, 5e-10]
+        a.particles["yunwrapped"] = a.initial_particles["yunwrapped"] + [1e-10, 1e-10]
+        msd = md.calculate_msd(a.particles, a.initial_particles)
+        assert_almost_equal(msd * 1e20, 14)
 
-    def test_calculate_msd_large(self):
+    def test_calculate_msd_is_zero_before_the_first_step(self):
+        # A 4 x 4 lattice in a 20 Angstrom box has particles either side of
+        # the box midpoint.
+        a = md.initialise(16, 300, 20, "square")
+        self.assertEqual(md.calculate_msd(a.particles, a.initial_particles), 0.0)
+
+    def test_calculate_msd_with_sparse_sampling(self):
+        # Both particles are driven in -x at 1e4 m/s, 0.1 Angstrom per step,
+        # so each crosses the periodic boundary around step 20 of 60 with no
+        # sampling in between. Moving together keeps their separation, and
+        # so the pair force, constant. The oracle accumulates the
+        # minimum-image displacement between consecutive steps, which is
+        # exact while a particle moves less than half a box per step.
         a = md.initialise(2, 300, 8, "square")
-        a.particles["xposition"] = [7e-10, 3e-10]
-        a.particles["yposition"] = [7e-10, 7e-10]
-        b = md.calculate_msd(a.particles, a.initial_particles, a.box_length)
-        assert_almost_equal(b, 10e-20)
+        a.particles["xvelocity"] = -1e4
+        a.particles["yvelocity"] = 0.0
+        box = a.box_length
+        total_dx = np.zeros(2)
+        total_dy = np.zeros(2)
+        for _ in range(60):
+            x_before = a.particles["xposition"].copy()
+            y_before = a.particles["yposition"].copy()
+            a.integrate(md.velocity_verlet)
+            dx = a.particles["xposition"] - x_before
+            dy = a.particles["yposition"] - y_before
+            total_dx += dx - box * np.round(dx / box)
+            total_dy += dy - box * np.round(dy / box)
+        self.assertTrue(np.all(total_dx < -5e-10))
+        expected = np.mean(total_dx**2 + total_dy**2)
+        msd = md.calculate_msd(a.particles, a.initial_particles)
+        assert_almost_equal(msd * 1e20, expected * 1e20)
 
     def test_initialise_accepts_diameter(self):
         a = md.initialise(2, 300, 8, "square", diameter=3.0)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -150,18 +150,18 @@ class TestMd(unittest.TestCase):
         assert_almost_equal(msd * 1e20, 14)
 
     def test_calculate_msd_is_zero_before_the_first_step(self):
-        # A 4 x 4 lattice in a 20 Angstrom box has particles either side of
-        # the box midpoint.
+        # The unwrapped positions start equal to the initial positions.
         a = md.initialise(16, 300, 20, "square")
         self.assertEqual(md.calculate_msd(a.particles, a.initial_particles), 0.0)
 
     def test_calculate_msd_with_sparse_sampling(self):
-        # Both particles are driven in -x at 1e4 m/s, 0.1 Angstrom per step,
-        # so each crosses the periodic boundary around step 20 of 60 with no
-        # sampling in between. Moving together keeps their separation, and
-        # so the pair force, constant. The oracle accumulates the
-        # minimum-image displacement between consecutive steps, which is
-        # exact while a particle moves less than half a box per step.
+        # Both particles are driven in -x at 1e4 m/s, 1 Angstrom per step, so
+        # each crosses the periodic boundary of the 8 Angstrom box several
+        # times in 60 steps with no sampling in between. Both share the same
+        # x, so the pair force acts only along y and the x motion is the
+        # imposed drift. The oracle accumulates the minimum-image
+        # displacement between consecutive steps, which is exact while a
+        # particle moves less than half a box per step.
         a = md.initialise(2, 300, 8, "square")
         a.particles["xvelocity"] = -1e4
         a.particles["yvelocity"] = 0.0

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -74,32 +74,41 @@ class TestMd(unittest.TestCase):
         )
         assert_almost_equal(system.pressure_sample[-1], expected)
 
-    def test_velocity_verlet(self):
+    def test_velocity_verlet_advances_the_unwrapped_positions(self):
+        # Two particles at (2, 2) and (2, 6) Angstrom in an 8 Angstrom box.
+        # A y velocity of 3e4 m/s moves each by 3 Angstrom in one 1e-14 s
+        # step, so the second particle crosses the boundary: its wrapped
+        # position comes back into the box and its unwrapped one does not.
         a = md.initialise(2, 300, 8, "square")
+        a.particles["xvelocity"] = 0.0
+        a.particles["yvelocity"] = 3e4
+        a.particles["xacceleration"] = 0.0
+        a.particles["yacceleration"] = 0.0
         a.particles, a.distances, a.forces, a.energies = md.velocity_verlet(
-            a.particles, 1, a.box_length, a.cut_off, a.constants, a.forcefield, a.mass
+            a.particles, 1e-14, a.box_length, a.cut_off, a.constants, a.forcefield, a.mass
         )
-        assert_almost_equal(a.particles["xprevious_position"] * 1e10, [2, 2])
-        assert_almost_equal(a.particles["yprevious_position"] * 1e10, [2, 6])
+        assert_almost_equal(a.particles["xunwrapped"] * 1e10, [2, 2])
+        assert_almost_equal(a.particles["yunwrapped"] * 1e10, [5, 9])
+        assert_almost_equal(a.particles["yposition"] * 1e10, [5, 1])
 
-    def test_update_positions(self):
+    def test_update_positions_wraps_the_position_and_not_the_unwrapped_one(self):
         a = md.initialise(2, 300, 8, "square")
         a.particles["xvelocity"] = 1e4
-        a.particles["yvelocity"] = 1e4
-        a.particles["xacceleration"] = 1e4
-        a.particles["yacceleration"] = 1e4
-        b, c = md.update_positions(
+        a.particles["yvelocity"] = 3e4
+        a.particles["xacceleration"] = 0.0
+        a.particles["yacceleration"] = 0.0
+        positions, unwrapped = md.update_positions(
             [a.particles["xposition"], a.particles["yposition"]],
-            [a.particles["xprevious_position"], a.particles["yprevious_position"]],
+            [a.particles["xunwrapped"], a.particles["yunwrapped"]],
             [a.particles["xvelocity"], a.particles["yvelocity"]],
             [a.particles["xacceleration"], a.particles["yacceleration"]],
-            a.timestep_length,
+            1e-14,
             a.box_length,
         )
-        assert_almost_equal(b[0][0] * 1e10, 3)
-        assert_almost_equal(b[1][0] * 1e10, 3)
-        assert_almost_equal(b[0][1] * 1e10, 3)
-        assert_almost_equal(b[1][1] * 1e10, 7)
+        assert_almost_equal(positions[0] * 1e10, [3, 3])
+        assert_almost_equal(positions[1] * 1e10, [5, 1])
+        assert_almost_equal(unwrapped[0] * 1e10, [3, 3])
+        assert_almost_equal(unwrapped[1] * 1e10, [5, 9])
 
     def test_update_velocities(self):
         a = md.initialise(2, 300, 8, "square")

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import forcefields as ff
-from pylj import util
+from pylj import mc, md, util
 
 # Sigma and epsilon in metres and joules for two Lennard-Jones species: argon,
 # and a larger particle with a 5 Angstrom core and the same well depth.
@@ -475,3 +475,56 @@ class TestUtil(unittest.TestCase):
             [1.69e-15, 3.66e10, 1.01e-77]
         ).energy(np.array([a.cores[0]]))[0]
         self.assertTrue(abs(core_energy) < 1e-3 * abs(well_depth))
+
+    def test_restart_starts_a_fresh_record_from_the_current_state(self):
+        system = md.initialise(4, 300, 12, "square")
+        for _ in range(5):
+            system.integrate(md.velocity_verlet)
+            system.step += 1
+            system.time += system.timestep_length
+            system.md_sample()
+        production = system.restart()
+        self.assertIsNot(production, system)
+        self.assertEqual(production.step, 0)
+        self.assertEqual(production.time, 0.0)
+        for name in (
+            "temperature_sample",
+            "pressure_sample",
+            "force_sample",
+            "msd_sample",
+            "energy_sample",
+            "step_sample",
+        ):
+            self.assertEqual(getattr(production, name).size, 0)
+        assert_equal(production.particles["xposition"], system.particles["xposition"])
+        assert_equal(production.particles["yposition"], system.particles["yposition"])
+        assert_equal(production.particles["xvelocity"], system.particles["xvelocity"])
+        assert_equal(production.particles["yvelocity"], system.particles["yvelocity"])
+        assert_equal(production.forces, system.forces)
+        self.assertEqual(
+            md.calculate_msd(production.particles, production.initial_particles), 0.0
+        )
+        self.assertEqual(production.simulation, "md")
+
+    def test_restart_leaves_the_source_alone(self):
+        system = md.initialise(4, 300, 12, "square")
+        for _ in range(3):
+            system.integrate(md.velocity_verlet)
+            system.step += 1
+            system.md_sample()
+        production = system.restart()
+        production.particles["xposition"] = 0.0
+        production.initial_particles["xunwrapped"] = 0.0
+        self.assertEqual(system.step, 3)
+        self.assertEqual(system.msd_sample.size, 3)
+        self.assertTrue(np.all(system.particles["xposition"] > 0.0))
+        self.assertTrue(np.all(system.initial_particles["xunwrapped"] > 0.0))
+
+    def test_restart_carries_the_accepted_energy_for_monte_carlo(self):
+        system = mc.initialise(4, 300, 12, "square")
+        system.mc_sample()
+        production = system.restart()
+        self.assertEqual(production.simulation, "mc")
+        self.assertEqual(production.old_energy, system.old_energy)
+        self.assertEqual(production.energy_sample.size, 0)
+        self.assertEqual(system.energy_sample.size, 1)

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -505,6 +505,10 @@ class TestUtil(unittest.TestCase):
             md.calculate_msd(production.particles, production.initial_particles), 0.0
         )
         self.assertEqual(production.simulation, "md")
+        # The origin stays where the run restarted while the particles move on.
+        production.integrate(md.velocity_verlet)
+        production.md_sample()
+        self.assertGreater(production.msd_sample[0], 0.0)
 
     def test_restart_leaves_the_source_alone(self):
         system = md.initialise(4, 300, 12, "square")

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -485,6 +485,7 @@ class TestUtil(unittest.TestCase):
             system.md_sample()
         production = system.restart()
         self.assertIsNot(production, system)
+        self.assertEqual(production.simulation, "md")
         self.assertEqual(production.step, 0)
         self.assertEqual(production.time, 0.0)
         for name in (
@@ -496,19 +497,22 @@ class TestUtil(unittest.TestCase):
             "step_sample",
         ):
             self.assertEqual(getattr(production, name).size, 0)
-        assert_equal(production.particles["xposition"], system.particles["xposition"])
-        assert_equal(production.particles["yposition"], system.particles["yposition"])
-        assert_equal(production.particles["xvelocity"], system.particles["xvelocity"])
-        assert_equal(production.particles["yvelocity"], system.particles["yvelocity"])
-        assert_equal(production.forces, system.forces)
         self.assertEqual(
             md.calculate_msd(production.particles, production.initial_particles), 0.0
         )
-        self.assertEqual(production.simulation, "md")
-        # The origin stays where the run restarted while the particles move on.
-        production.integrate(md.velocity_verlet)
+        # Sampling straight after the restart uses the copied pair arrays.
+        system.md_sample()
         production.md_sample()
-        self.assertGreater(production.msd_sample[0], 0.0)
+        self.assertEqual(production.pressure_sample[0], system.pressure_sample[-1])
+        self.assertEqual(production.energy_sample[0], system.energy_sample[-1])
+        # The restarted system follows the same trajectory as the source
+        # while its displacement is measured from the restart.
+        system.integrate(md.velocity_verlet)
+        production.integrate(md.velocity_verlet)
+        assert_equal(production.particles["xposition"], system.particles["xposition"])
+        assert_equal(production.particles["yposition"], system.particles["yposition"])
+        production.md_sample()
+        self.assertGreater(production.msd_sample[-1], 0.0)
 
     def test_restart_leaves_the_source_alone(self):
         system = md.initialise(4, 300, 12, "square")
@@ -516,13 +520,15 @@ class TestUtil(unittest.TestCase):
             system.integrate(md.velocity_verlet)
             system.step += 1
             system.md_sample()
+        positions = system.particles["xposition"].copy()
+        origin = system.initial_particles["xunwrapped"].copy()
         production = system.restart()
         production.particles["xposition"] = 0.0
         production.initial_particles["xunwrapped"] = 0.0
         self.assertEqual(system.step, 3)
         self.assertEqual(system.msd_sample.size, 3)
-        self.assertTrue(np.all(system.particles["xposition"] > 0.0))
-        self.assertTrue(np.all(system.initial_particles["xunwrapped"] > 0.0))
+        assert_equal(system.particles["xposition"], positions)
+        assert_equal(system.initial_particles["xunwrapped"], origin)
 
     def test_restart_carries_the_accepted_energy_for_monte_carlo(self):
         system = mc.initialise(4, 300, 12, "square")

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -129,6 +129,8 @@ class System:
                 "not recognised. Available options are: "
                 "square or random"
             )
+        self.particles["xunwrapped"] = self.particles["xposition"]
+        self.particles["yunwrapped"] = self.particles["yposition"]
         if box_length > 30:
             self.cut_off = cut_off * 1e-10
         else:
@@ -517,12 +519,13 @@ def __version__():  # pragma: no cover
 
 def particle_dt():
     """Builds the data type for the particles, this consists of:
-    
-    - xposition and yposition
+
+    - xposition and yposition, wrapped into the simulation cell
+    - xunwrapped and yunwrapped, the positions without periodic wrapping,
+      advanced by md.velocity_verlet and used for the mean squared
+      displacement
     - xvelocity and yvelocity
     - xacceleration and yacceleration
-    - xprevious_position and yprevious_position
-    - xforce and yforce
     - energy
     - types
     """
@@ -530,15 +533,13 @@ def particle_dt():
         [
             ("xposition", np.float64),
             ("yposition", np.float64),
+            ("xunwrapped", np.float64),
+            ("yunwrapped", np.float64),
             ("xvelocity", np.float64),
             ("yvelocity", np.float64),
             ("xacceleration", np.float64),
             ("yacceleration", np.float64),
-            ("xprevious_position", np.float64),
-            ("yprevious_position", np.float64),
             ("energy", np.float64),
-            ("xpbccount", int),
-            ("ypbccount", int),
-            ("types", list)
+            ("types", list),
         ]
     )

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -189,7 +189,8 @@ class System:
             The new system.
         """
         # A shallow copy shares the box, forcefield and constants, which never
-        # change; everything a run changes is copied or reset below.
+        # change, and keeps the accepted energy; the state that belongs to one
+        # run is copied or reset below.
         new = copy.copy(self)
         new.particles = self.particles.copy()
         new.particles["xunwrapped"] = new.particles["xposition"]

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -1,3 +1,4 @@
+import copy
 import webbrowser
 from collections.abc import Iterable
 from typing import Literal
@@ -160,6 +161,49 @@ class System:
             Number of pairwise interactions in the system.
         """
         return int((self.number_of_particles - 1) * self.number_of_particles / 2)
+
+    def restart(self) -> "System":
+        """Return a new system that continues from the current configuration.
+
+        The new system keeps the box, forcefield, constants, mass, timestep
+        and cut-off, and copies the particle positions, velocities and
+        accelerations and the pair forces. Its step and time are zero, its
+        sample arrays are empty, and the mean squared displacement is
+        measured from the copied positions. The current system is not
+        changed. Use it to start a production run after equilibration::
+
+            system = md.initialise(100, 300, 40, "random")
+            for _ in range(1000):
+                system.integrate(md.velocity_verlet)
+                system.heat_bath(300)
+            production = system.restart()
+            for _ in range(5000):
+                production.integrate(md.velocity_verlet)
+                production.step += 1
+                production.md_sample()
+
+        Returns:
+            The new system.
+        """
+        new = copy.copy(self)
+        new.particles = self.particles.copy()
+        new.particles["xunwrapped"] = new.particles["xposition"]
+        new.particles["yunwrapped"] = new.particles["yposition"]
+        new.initial_particles = new.particles.copy()
+        new.distances = self.distances.copy()
+        new.forces = self.forces.copy()
+        new.energies = self.energies.copy()
+        new.step = 0
+        new.time = 0.0
+        new.temperature_sample = np.array([])
+        new.pressure_sample = np.array([])
+        new.force_sample = np.array([])
+        new.msd_sample = np.array([])
+        new.energy_sample = np.array([])
+        new.step_sample = np.array([])
+        new.position_store = [0, 0]
+        new.random_particle = 0
+        return new
 
     def square(self) -> None:
         """Places the particles on a square lattice.

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -1,7 +1,7 @@
 import copy
 import webbrowser
 from collections.abc import Iterable
-from typing import Literal
+from typing import Literal, Self
 
 import numpy as np
 
@@ -162,14 +162,14 @@ class System:
         """
         return int((self.number_of_particles - 1) * self.number_of_particles / 2)
 
-    def restart(self) -> "System":
+    def restart(self) -> Self:
         """Return a new system that continues from the current configuration.
 
         The new system keeps the box, forcefield, constants, mass, timestep
         and cut-off, and copies the particle positions, velocities and
-        accelerations and the pair distances, forces and energies. Its step
-        and time are zero, its
-        sample arrays are empty, and the mean squared displacement is
+        accelerations and the pair distances, forces and energies. A Monte
+        Carlo system also keeps its accepted energy. Step and time are zero,
+        the sample arrays are empty, and the mean squared displacement is
         measured from the copied positions. The current system is not
         changed. Use it to start a production run after equilibration::
 
@@ -205,6 +205,7 @@ class System:
         new.msd_sample = np.array([])
         new.energy_sample = np.array([])
         new.step_sample = np.array([])
+        new.new_energy = 0
         new.position_store = [0, 0]
         new.random_particle = 0
         return new

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -167,7 +167,8 @@ class System:
 
         The new system keeps the box, forcefield, constants, mass, timestep
         and cut-off, and copies the particle positions, velocities and
-        accelerations and the pair forces. Its step and time are zero, its
+        accelerations and the pair distances, forces and energies. Its step
+        and time are zero, its
         sample arrays are empty, and the mean squared displacement is
         measured from the copied positions. The current system is not
         changed. Use it to start a production run after equilibration::
@@ -180,11 +181,14 @@ class System:
             for _ in range(5000):
                 production.integrate(md.velocity_verlet)
                 production.step += 1
+                production.time += production.timestep_length
                 production.md_sample()
 
         Returns:
             The new system.
         """
+        # A shallow copy shares the box, forcefield and constants, which never
+        # change; the arrays that a run changes are copied below.
         new = copy.copy(self)
         new.particles = self.particles.copy()
         new.particles["xunwrapped"] = new.particles["xposition"]

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -169,9 +169,10 @@ class System:
         and cut-off, and copies the particle positions, velocities and
         accelerations and the pair distances, forces and energies. A Monte
         Carlo system also keeps its accepted energy. Step and time are zero,
-        the sample arrays are empty, and the mean squared displacement is
-        measured from the copied positions. The current system is not
-        changed. Use it to start a production run after equilibration::
+        the sample arrays are empty, and initial_particles is replaced by the
+        copied particles, so the mean squared displacement is measured from
+        the restarted configuration. The current system is not changed. Use
+        it to start a production run after equilibration::
 
             system = md.initialise(100, 300, 40, "random")
             for _ in range(1000):
@@ -188,7 +189,7 @@ class System:
             The new system.
         """
         # A shallow copy shares the box, forcefield and constants, which never
-        # change; the arrays that a run changes are copied below.
+        # change; everything a run changes is copied or reset below.
         new = copy.copy(self)
         new.particles = self.particles.copy()
         new.particles["xunwrapped"] = new.particles["xposition"]
@@ -571,8 +572,8 @@ def particle_dt():
 
     - xposition and yposition, wrapped into the simulation cell
     - xunwrapped and yunwrapped, the positions without periodic wrapping,
-      advanced by md.velocity_verlet and used for the mean squared
-      displacement
+      advanced by md.velocity_verlet only and used for the mean squared
+      displacement; Monte Carlo moves leave them unchanged
     - xvelocity and yvelocity
     - xacceleration and yacceleration
     - energy


### PR DESCRIPTION
Resolves #74.

The mean squared displacement counted a periodic-boundary crossing only if it happened in the step immediately before a sample, so it was wrong unless `md.sample` ran every step, and it was non-zero before the first step because the previous position started at zero.

- The particle dtype carries `xunwrapped` and `yunwrapped`, positions without periodic wrapping. `md.update_positions` advances them by the same displacement as the wrapped positions, and `md.velocity_verlet` stores them. The crossing counters and previous positions are removed.
- `md.calculate_msd(particles, initial_particles)` is a pure function of the current and reference unwrapped positions, correct at any sampling cadence and exactly zero at step zero. It no longer takes `box_length`.
- `System.restart()` returns a new system that continues from the current configuration: particles, velocities and pair forces copied, step and time at zero, empty sample arrays, MSD origin at the copied positions. It works for MD and MC systems and leaves the source untouched. The pattern is initialise, equilibrate, `production = system.restart()`, run and sample.

The MSD is pinned against an independent step-by-step minimum-image unwrap over a trajectory that crosses the boundary several times between samples, and the restarted MSD is checked to grow from zero, which an origin aliased to the particle array would not.
