### PR TITLE
Place initial configurations by Metropolis insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
+- `md.initialise` refuses an initial configuration whose pair energy is not finite or whose forces would move a particle further than the box in one step, as when particles overlap or the potential's parameters are in the wrong units; `mc.initialise` refuses a non-finite initial energy.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
-- `util.check_initial_energy`, used by `md.initialise` and `mc.initialise`, refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the temperature it could heat to.
-- `System` refuses a pair potential whose energy at the cut-off is not finite or is larger in magnitude than k_B T, since the cut-off assumes the interaction has died away there; parameters in the wrong units are one way to trip it. `mc.accept` refuses a NaN energy change.
+- `System` refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the stored energy per particle in k_B T.
+- `System` refuses a pair potential whose energy at the cut-off is not finite or is larger in magnitude than k_B T, since the cut-off assumes the interaction has died away there; parameters in the wrong units are one way to trip it.
+- `System` raises `ValueError`, not `AttributeError`, for a box length outside 4 to 600 Angstrom.
+- `LennardJones` is `+inf` at zero separation, where it was NaN.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed
@@ -56,7 +58,7 @@ All notable changes to pylj are recorded here. The format follows
 - The Metropolis criterion, `mc.accept`, draws a fresh random number for every uphill change (a downhill change is accepted without a draw); one was reused for the life of the process (#78).
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
-- `'metropolis'` initial configurations do not overlap (#82).
+- `'metropolis'` initial configurations do not overlap at the placement temperature (#82).
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
 - The mean squared displacement was wrong unless sampled on every integration step, and non-zero before the first step (#74).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ All notable changes to pylj are recorded here. The format follows
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
 - Initial configurations no longer overlap: `'metropolis'` placement rejects overlapping trial positions by their energy (#82).
-- A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units) is refused with a clear message.
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
 - The mean squared displacement was wrong unless sampled on every integration step, and non-zero before the first step (#74).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
-- `util.check_initial_energy`, used by `md.initialise` and `mc.initialise`, refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the temperature it could heat to. `System` refuses a pair potential whose energy is still above k_B T at the cut-off, as one with parameters in the wrong units is.
+- `util.check_initial_energy`, used by `md.initialise` and `mc.initialise`, refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the temperature it could heat to.
+- `System` refuses a pair potential whose energy is still above k_B T at the cut-off, as one with parameters in the wrong units is. `mc.accept` refuses a NaN energy change.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed
@@ -55,7 +56,7 @@ All notable changes to pylj are recorded here. The format follows
 - The Metropolis criterion, `mc.accept`, draws a fresh random number for every uphill change (a downhill change is accepted without a draw); one was reused for the life of the process (#78).
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
-- `init_conf='metropolis'` places initial configurations without overlapping particles, rejecting trial positions by their energy (#82).
+- `'metropolis'` initial configurations do not overlap (#82).
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
 - The mean squared displacement was wrong unless sampled on every integration step, and non-zero before the first step (#74).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ All notable changes to pylj are recorded here. The format follows
 - `pylj.constants`, taking the Boltzmann constant and the atomic mass unit from `scipy.constants`.
 - ruff and mypy configuration in `pyproject.toml`, a `dev` extra, and continuous integration on Python 3.11 to 3.14.
 - `System.restart()` returns a new system that continues from the current configuration with step and time at zero, empty sample arrays and the mean squared displacement measured from the copied positions, for starting a production run after equilibration.
-- `seed` on `md.initialise`, `mc.initialise` and `System`, and `System.rng`, the `numpy.random.Generator` that places a random configuration, draws the initial velocities and makes Monte Carlo moves. The same seed reproduces the same run.
+- `seed` on `md.initialise`, `mc.initialise` and `System`, and `System.rng`, the `numpy.random.Generator` that places an initial configuration, draws the initial velocities and makes Monte Carlo moves. The same seed reproduces the same run.
 - `pylj.potentials`: `Species`, a frozen dataclass of mass and name; the `PairPotential` interface, `energies(dr)` and `forces(dr)` on an array of separations, the force being the signed radial `-dE/dr`; and `LennardJones(*, epsilon, sigma)`, `Buckingham(*, a, b, c)` and `SquareWell(*, epsilon, sigma, lambda_, max_val)`, keyword-only with physical parameters (#57). `Species` rejects a non-positive or non-finite mass.
 - `pairwise.compute_energy`, which evaluates the pair distances and energies without calling `forces`, so a potential with no finite force drives Monte Carlo; `System.compute_energy` uses it.
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
-- `md.initialise` refuses an initial configuration whose pair energy is not finite or whose forces would move a particle further than the box in one step, as when particles overlap or the potential's parameters are in the wrong units; `mc.initialise` refuses a non-finite initial energy.
+- `md.initialise` and `mc.initialise` refuse an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, the equipartition temperature it would heat to, as an overlapping lattice does. `System` refuses a potential whose own pair energy is still above k_B T at the cut-off, as one with parameters in the wrong units is.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed
@@ -55,7 +55,7 @@ All notable changes to pylj are recorded here. The format follows
 - The Metropolis criterion, `mc.accept`, draws a fresh random number for every uphill change (a downhill change is accepted without a draw); one was reused for the life of the process (#78).
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
-- Initial configurations no longer overlap: `'metropolis'` placement rejects overlapping trial positions by their energy (#82).
+- `init_conf='metropolis'` places initial configurations without overlapping particles, rejecting trial positions by their energy (#82).
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
 - The mean squared displacement was wrong unless sampled on every integration step, and non-zero before the first step (#74).
@@ -69,4 +69,4 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.separation`, `pairwise.pbc_correction`, `pairwise.second_law`, and the deprecated `pairwise.lennard_jones_energy` and `pairwise.lennard_jones_force` wrappers.
 - `System.select_random_particle`, `new_random_position`, `metropolis`, `accept` and `reject`, with `old_energy`, `new_energy`, `position_store` and `random_particle`; `mc.select_random_particle`, `mc.get_new_particle`, `mc.reject`, `mc.metropolis`, and the identity `mc.accept(new_energy)`; the unused `energy` field of the particle dtype.
 - `pylj.forcefields` and its `mixing` and `diameter` members; cross-species potentials are entries in `pair_potentials`. `md.compute_force` (a wrapper of `pairwise.compute_force`), `util.Particle`, `System.setup_types`, `System.setup_diameters` and `System.diameters`.
-- `System.cores`, `System.setup_cores`, `System.random`, and the geometric overlap and density guards on placement, with their error messages.
+- The `'random'` initial configuration, replaced by `'metropolis'`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to pylj are recorded here. The format follows
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
 - `util.check_initial_energy`, used by `md.initialise` and `mc.initialise`, refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the temperature it could heat to.
-- `System` refuses a pair potential whose energy is still above k_B T at the cut-off, as one with parameters in the wrong units is. `mc.accept` refuses a NaN energy change.
+- `System` refuses a pair potential whose energy at the cut-off is not finite or is larger in magnitude than k_B T, since the cut-off assumes the interaction has died away there; parameters in the wrong units are one way to trip it. `mc.accept` refuses a NaN energy change.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
-- `md.initialise` and `mc.initialise` refuse an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, the equipartition temperature it would heat to, as an overlapping lattice does. `System` refuses a potential whose own pair energy is still above k_B T at the cut-off, as one with parameters in the wrong units is.
+- `util.check_initial_energy`, used by `md.initialise` and `mc.initialise`, refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the temperature it could heat to. `System` refuses a pair potential whose energy is still above k_B T at the cut-off, as one with parameters in the wrong units is.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,18 @@ All notable changes to pylj are recorded here. The format follows
 - ruff and mypy configuration in `pyproject.toml`, a `dev` extra, and continuous integration on Python 3.11 to 3.14.
 - `System.restart()` returns a new system that continues from the current configuration with step and time at zero, empty sample arrays and the mean squared displacement measured from the copied positions, for starting a production run after equilibration.
 - `seed` on `md.initialise`, `mc.initialise` and `System`, and `System.rng`, the `numpy.random.Generator` that places an initial configuration, draws the initial velocities and makes Monte Carlo moves. The same seed reproduces the same run.
-- `pylj.potentials`: `Species`, a frozen dataclass of mass and name; the `PairPotential` interface, `energies(dr)` and `forces(dr)` on an array of separations, the force being the signed radial `-dE/dr`; and `LennardJones(*, epsilon, sigma)`, `Buckingham(*, a, b, c)` and `SquareWell(*, epsilon, sigma, lambda_, max_val)`, keyword-only with physical parameters (#57). `Species` rejects a non-positive or non-finite mass.
+- `pylj.potentials`: `Species`, a frozen dataclass of mass and name; the `PairPotential` interface, `energies(dr)` and `forces(dr)` on an array of separations, the force being the signed radial `-dE/dr`; and `LennardJones(*, epsilon, sigma)`, `Buckingham(*, a, b, c)` and `SquareWell(*, epsilon, sigma, lambda_, max_val)`, keyword-only with physical parameters (#57). `Species` rejects a non-positive or non-finite mass. `LennardJones` is infinite at zero separation, and `Buckingham` is infinite inside its short-range barrier, whose separation it exposes as `turnover`, in place of the form's collapse to minus infinity there.
 - `pairwise.compute_energy`, which evaluates the pair distances and energies without calling `forces`, so a potential with no finite force drives Monte Carlo; `System.compute_energy` uses it.
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
 - `System` refuses an initial configuration whose pair energy is not finite or stores more than `util.INITIAL_ENERGY_LIMIT` (ten) k_B T per particle, as an overlapping lattice does; the message gives the stored energy per particle in k_B T.
 - `System` refuses a pair potential whose energy at the cut-off is not finite or is larger in magnitude than k_B T, since the cut-off assumes the interaction has died away there; parameters in the wrong units are one way to trip it.
-- `System` raises `ValueError`, not `AttributeError`, for a box length outside 4 to 600 Angstrom.
-- `LennardJones` is `+inf` at zero separation, where it was NaN.
 - `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed
 
+- `System` raises `ValueError`, not `AttributeError`, for a box length outside 4 to 600 Angstrom.
 - `md.heat_bath(particles, mass, bath_temperature)` rescales on the instantaneous temperature; it previously took the temperature sample array and rescaled towards its cumulative mean. `System.heat_bath(bath_temperature)` is unchanged. A non-positive bath temperature, or a system with zero or non-finite temperature, raises `ValueError` (#76).
 - Python 3.11 or later is required. scipy is a dependency; Cython is not.
 - `System.__init__` takes keyword-only arguments after `mass`, including the required `simulation`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to pylj are recorded here. The format follows
 - `System.simulation`, `'md'` or `'mc'`, set by the initialisers.
 - `step_sample` on `System`, recorded by `md.sample` and `mc.sample`, so viewers work at any sampling cadence.
 - A `diameter` property on every forcefield (the separation at the pair-potential minimum) and a `diameter` argument on `md.initialise` and `mc.initialise` to override it, in Angstrom. Particles are drawn to scale.
-- `System.cores`, the separation at which each forcefield's pair energy falls to zero, found numerically from its `energy` method. Initial configurations keep particles at least this far apart.
 - `pylj.constants`, taking the Boltzmann constant and the atomic mass unit from `scipy.constants`.
 - ruff and mypy configuration in `pyproject.toml`, a `dev` extra, and continuous integration on Python 3.11 to 3.14.
 - `System.restart()` returns a new system that continues from the current configuration with step and time at zero, empty sample arrays and the mean squared displacement measured from the copied positions, for starting a production run after equilibration.
@@ -21,6 +20,7 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.pair_potential` and `pairwise.particle_masses`.
 - `CellPane(diameter=...)` and a `diameter` keyword on every named viewer, in Angstrom, one value or one per species; by default particles are drawn at the separation of the minimum of their species' own pair energy.
 - `mc.accept`, the Metropolis criterion on an energy change; `mc.Proposal`, a proposed configuration with its energy change; `pairwise.particle_energy`, one particle's interaction energy with a set of others; `System.propose`, `System.apply` and `System.energy`, the total pair energy of the current configuration.
+- `placement_temperature` on `md.initialise`, `mc.initialise` and `System`: the temperature of the Metropolis acceptance used to place an initial configuration, by default the run temperature.
 
 ### Changed
 
@@ -43,6 +43,7 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.compute_force(particles, box_length, cut_off, pair_potentials, species)` resolves each pair of species to its potential and divides each pair force by the receiving particle's own mass; `pairwise.update_accelerations` takes the mass of each particle. `md.velocity_verlet` takes `pair_potentials` and `species`. `md.calculate_temperature` and `md.heat_bath` accept one mass per particle.
 - Initial velocities are drawn with each particle's own thermal width and the mass-weighted centre-of-mass velocity is removed.
 - The Monte Carlo loop proposes a configuration and applies it on acceptance, leaving the configuration untouched otherwise; a trial move costs O(N). `System.mc_sample` recomputes the pair distances and energies and sets `energy` to the exact total before recording. `System.init_temp` is `System.temperature`.
+- `init_conf` takes `'square'` or `'metropolis'`. `'metropolis'` seats particles by sequential Metropolis insertion, each trial position accepted on its interaction energy with the particles already placed, in place of the `'random'` rejection-sampled placement; it works for any potential, including a hard core. `'square'` places on the lattice without an overlap check.
 
 ### Fixed
 
@@ -53,8 +54,7 @@ All notable changes to pylj are recorded here. The format follows
 - The Metropolis criterion, `mc.accept`, draws a fresh random number for every uphill change (a downhill change is accepted without a draw); one was reused for the life of the process (#78).
 - The square-well hard core tested epsilon rather than sigma (part of #80), and `square_well.energy` failed on integer input.
 - A custom forcefield without a `diameter` property, a diameter given in metres, or a non-positive or non-finite diameter (whether from the forcefield or passed by the caller) is refused with a clear message.
-- Random initial configurations no longer overlap: particles are placed at least their repulsive-core separation apart (#82).
-- The square lattice refuses a spacing below the repulsive core, with the largest count or the smallest box that fits, rounded up so the suggested box is accepted, in the message (#82).
+- Initial configurations no longer overlap: `'metropolis'` placement rejects overlapping trial positions by their energy (#82).
 - A forcefield whose `energy` does not return one value per separation, whose pair energy is positive at every grid point (suggesting its constants are in the wrong units) is refused with a clear message.
 - `energy` and `force` on the forcefields no longer store their result on `self`, overwriting the bound method and breaking a second call on the same instance (#79).
 - `buckingham.energy` and `buckingham.force` raised under NumPy 2.1 or later when the separation was an integer, a 0-d array, or a NumPy scalar that is not a float subclass (#83). `lennard_jones` and `lennard_jones_sigma_epsilon` also failed on integer input.
@@ -69,3 +69,4 @@ All notable changes to pylj are recorded here. The format follows
 - `pairwise.separation`, `pairwise.pbc_correction`, `pairwise.second_law`, and the deprecated `pairwise.lennard_jones_energy` and `pairwise.lennard_jones_force` wrappers.
 - `System.select_random_particle`, `new_random_position`, `metropolis`, `accept` and `reject`, with `old_energy`, `new_energy`, `position_store` and `random_particle`; `mc.select_random_particle`, `mc.get_new_particle`, `mc.reject`, `mc.metropolis`, and the identity `mc.accept(new_energy)`; the unused `energy` field of the particle dtype.
 - `pylj.forcefields` and its `mixing` and `diameter` members; cross-species potentials are entries in `pair_potentials`. `md.compute_force` (a wrapper of `pairwise.compute_force`), `util.Particle`, `System.setup_types`, `System.setup_diameters` and `System.diameters`.
+- `System.cores`, `System.setup_cores`, `System.random`, and the geometric overlap and density guards on placement, with their error messages.

--- a/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
+++ b/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
@@ -159,14 +159,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above example, a `square` distribution of particles is assigned, however, it is also possible to distribute the particles through the cell by Metropolis insertion (with the keyword `metropolis`). Try this out in the cell above and comment below on why this might cause issues for the molecular dynamics simulation. "
+    "In the above example, a `square` lattice of particles is assigned, however, it is also possible to seat the particles by Metropolis insertion (with the keyword `metropolis`), which places them one at a time and accepts each position according to its interaction energy with the particles already placed. Try this out in the cell above and compare the two starting configurations. Comment below on what a starting configuration needs to provide for a molecular dynamics simulation, and on why placing the particles at random, without regard to their energy, would be a poor start."
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# Comment on the problems of starting in a random configuration. Consider the possible problems of simulations that start at very high energy. "
+    "# Comment on what makes a good starting configuration. Consider the possible problems of simulations that start at very high energy. "
    ]
   },
   {

--- a/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
+++ b/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above example, a `square` distribution of particles is assigned, however, it is also possible to distribute the particles randomly through the cell (with the keyword `random`). Try this out in the cell above and comment below on why this might cause issues for the molecular dynamics simulation. "
+    "In the above example, a `square` distribution of particles is assigned, however, it is also possible to distribute the particles through the cell by Metropolis insertion (with the keyword `metropolis`). Try this out in the cell above and comment below on why this might cause issues for the molecular dynamics simulation. "
    ]
   },
   {

--- a/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
+++ b/examples/molecular_dynamics/intro_to_molecular_dynamics.ipynb
@@ -92,7 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are going to use the software pylj. This is a Python library, which means it is a collection of functions to enable the simulation of molecular dynamics. An example is the `forcefields.lennard_jones` class: given the constants A and B, its `energy` method does the same job as the `lennard_jones` function that you have defined above."
+    "We are going to use the software pylj. This is a Python library, which means it is a collection of functions to enable the simulation of molecular dynamics. An example is the `LennardJones` class: given the well depth ε and the zero-crossing σ, its `energies` method does the same job as the `lennard_jones` function that you have defined above. The cell at the top of the notebook builds one for argon, `lj`."
    ]
   },
   {
@@ -173,11 +173,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another important aspect of the initialisation process is to assign the initial velocities for each of the particles. This is achieved using the following equation, \n",
+    "Another important aspect of the initialisation process is to assign the initial velocities for each of the particles. Each component of each particle's velocity is drawn from a normal distribution with zero mean and variance\n",
     "\n",
-    "$$ \\mathbf{v}_i = (n_i - \\bar{n}) \\sqrt{\\frac{2T}{\\sum_i^N n^2}}, $$\n",
+    "$$ \\langle v^2 \\rangle = \\frac{k_B T}{m}, $$\n",
     "\n",
-    "where $n_i$ is a series of numbers of length $N$, where $N$ is the number of particles, drawn from a uniform distribution between 0 and 1, $\\bar{n}$ is the mean $n_i$, and $T$ is the initial temperature of the system. The range of values for the velocities can be found for the system above using the following command."
+    "where $m$ is the particle's mass and $T$ is the initial temperature of the system. The velocity of the centre of mass is then subtracted, so that the box as a whole does not drift, and the velocities are rescaled so that the kinetic temperature is exactly $T$. The velocities of the system above can be printed using the following command."
    ]
   },
   {
@@ -198,11 +198,11 @@
     "\n",
     "### Calculate forces\n",
     "\n",
-    "The next stage is to calculate the forces on each of the particles. The forces on each of the atoms can be force directly from the energy (which is given by the Lennard-Jones function discussed above), as the force is the negative of the first derivative of the energy with respect to the distance, \n",
+    "The next stage is to calculate the forces on each of the particles. The forces on each of the atoms can be found directly from the energy (which is given by the Lennard-Jones function discussed above), as the force is the negative of the first derivative of the energy with respect to the distance, \n",
     "\n",
     "$$ \\mathbf{f} = -\\frac{\\partial E}{\\partial r}. $$\n",
     "\n",
-    "The force of a given interaction can be found using the `forcefields.lennard(dr, constants, force=True)` function available in pylj, below plot the force for the interaction between two argon atoms as was completed for the energy above. "
+    "The force of a given interaction can be found using the `forces` method of the potential, `lj.forces(r)`. Below, plot the force for the interaction between two argon atoms as was completed for the energy above."
    ]
   },
   {

--- a/examples/monte_carlo/intro_to_monte_carlo.ipynb
+++ b/examples/monte_carlo/intro_to_monte_carlo.ipynb
@@ -163,7 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above example, a `square` distribution of particles is assigned, however, it is also possible to distribute the particles randomly through the cell (with the keyword `random`), try this out in the cell above. \n",
+    "In the above example, a `square` distribution of particles is assigned, however, it is also possible to distribute the particles through the cell by Metropolis insertion (with the keyword `metropolis`), try this out in the cell above. \n",
     "\n",
     "### Calculate energy \n",
     "\n",

--- a/examples/monte_carlo/intro_to_monte_carlo.ipynb
+++ b/examples/monte_carlo/intro_to_monte_carlo.ipynb
@@ -219,8 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "proposal = simulation.propose()\n",
-    "print(proposal)"
+    "proposal = simulation.propose()"
    ]
   },
   {

--- a/examples/monte_carlo/intro_to_monte_carlo.ipynb
+++ b/examples/monte_carlo/intro_to_monte_carlo.ipynb
@@ -94,7 +94,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are going to use the software pylj. This is a Python library, which means it is a collection of functions to enable the simulation by Monte Carlo. An example of a function in pylj is the `forcefields.lennard_jones`, which can be used similar to the `lennard_jones` function that you have defined above."
+    "We are going to use the software pylj. This is a Python library, which means it is a collection of functions to enable the simulation by Monte Carlo. An example is the `LennardJones` class: given the well depth ε and the zero-crossing σ, its `energies` method does the same job as the `lennard_jones` function that you have defined above. The cell at the top of the notebook builds one for argon, `lj`."
    ]
   },
   {
@@ -244,7 +244,7 @@
    "source": [
     "### Find the new energy\n",
     "\n",
-    "The total energy of the system in Monte Carlo is generally in the units of joules per atom (or molecule). Define below a function to calculate the total energy from the energy of the individual interactions."
+    "The total energy of the system is the sum of the energies of all of its pairwise interactions, in joules. Define below a function to calculate the total energy from the energy of the individual interactions."
    ]
   },
   {
@@ -325,12 +325,12 @@
    "source": [
     "### Build the loop\n",
     "\n",
-    "A Monte Carlo step is therefore: propose a move, decide with the Metropolis condition, and apply the move if it was accepted.\n",
+    "A Monte Carlo step is therefore: propose a move, decide with the Metropolis condition at the simulation's temperature, and apply the move if it was accepted.\n",
     "\n",
     "```python\n",
     "\n",
     "proposal = simulation.propose()\n",
-    "if mc.accept(proposal.energy_change, temperature):\n",
+    "if mc.accept(proposal.energy_change, simulation.temperature):\n",
     "    simulation.apply(proposal)\n",
     "\n",
     "```\n",

--- a/examples/monte_carlo/intro_to_monte_carlo.ipynb
+++ b/examples/monte_carlo/intro_to_monte_carlo.ipynb
@@ -206,11 +206,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the particles are more than 15 Å (or half the box length if the box length is less than 30 Å), the energy is automatically assigned as 0, since the particles are considered to be far enough apart that there interaction is negligible.\n",
+    "If the particles are more than 15 Å apart (or half the box length if the box length is less than 30 Å), the energy is automatically assigned as 0, since the particles are considered to be far enough apart that their interaction is negligible.\n",
     "\n",
-    "### Make a change\n",
+    "### Propose a change\n",
     "\n",
-    "Then a change is made to the system, in Monte Carlo generally this can be a wide variety of types of change, such as the number of particles, their position, and the volume of the system. We will focus on modifying the positions of the particles, which is achieved through the following pair of functions."
+    "Then a change is made to the system, in Monte Carlo generally this can be a wide variety of types of change, such as the number of particles, their position, and the volume of the system. We will focus on modifying the positions of the particles. The `propose` method picks a particle at random, draws a new position for it, and returns a `Proposal` describing the move. The system itself is not changed yet."
    ]
   },
   {
@@ -219,15 +219,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation.select_random_particle()\n",
-    "simulation.new_random_position()"
+    "proposal = simulation.propose()\n",
+    "print(proposal)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we then print the energies of the interactions again hopefully it is possible to see the difference. "
+    "The proposal carries the change in the total energy that the move would cause, `proposal.energy_change`, found from the energies of the moved particle's interactions before and after the move."
    ]
   },
   {
@@ -236,9 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation.compute_energy()\n",
-    "new_energies = simulation.energies\n",
-    "print(new_energies)"
+    "print(proposal.energy_change)"
    ]
   },
   {
@@ -247,7 +245,7 @@
    "source": [
     "### Find the new energy\n",
     "\n",
-    "The total energy of the system in Monte Carlo is generally in the units of joules per atom (or molecule). Define below a function to calculate the total energy from the energy of the individual interactions. "
+    "The total energy of the system in Monte Carlo is generally in the units of joules per atom (or molecule). Define below a function to calculate the total energy from the energy of the individual interactions."
    ]
   },
   {
@@ -266,7 +264,7 @@
    "source": [
     "### Comparing the energies\n",
     "\n",
-    "It is then possible to compare the energy of the system before and after the move."
+    "It is then possible to compare the energy of the system before and after the move: the energy before is the total of the interaction energies printed above, and the energy after is that total plus the change the proposal reports."
    ]
   },
   {
@@ -275,7 +273,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if total_energy( new_energy, ◽◽◽ ) < total_energy( old_energy, ◽◽◽ ):\n",
+    "old_energy = total_energy( old_energies, ◽◽◽ )\n",
+    "new_energy = old_energy + proposal.energy_change\n",
+    "if new_energy < old_energy:\n",
     "    print('The energy has decreased!')\n",
     "else:\n",
     "    print('The energy increased :(')"
@@ -287,9 +287,9 @@
    "source": [
     "However, we are not just interested in if the energy has decreased as we want Boltzmann probabilities of the possible states. This requires the Metropolis condition, where the change is accepted if, \n",
     "\n",
-    "$$ n < \\exp{\\bigg(\\frac{E_{\\text{new}} - E_{\\text{old}}}{k_BT}\\bigg)}, $$  \n",
+    "$$ n < \\exp{\\bigg(-\\frac{E_{\\text{new}} - E_{\\text{old}}}{k_BT}\\bigg)}, $$  \n",
     "\n",
-    "where $n\\sim U(0, 1)$, $k_B$ is the Boltzmann constant, and $T$ is the temperature. This is implemented in pylj using the `mc.metropolis` function."
+    "where $n\\sim U(0, 1)$, $k_B$ is the Boltzmann constant, and $T$ is the temperature. A move that lowers the energy is always accepted, and a move that raises it is accepted with a probability that falls off with the energy increase. This is implemented in pylj using the `mc.accept` function, which takes the energy change and the temperature."
    ]
   },
   {
@@ -298,14 +298,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mc.metropolis(300, total_energy(old_energies, ◽◽◽ ), total_energy(new_energies, ◽◽◽ ))"
+    "accepted = mc.accept(proposal.energy_change, 300)\n",
+    "print(accepted)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This returns `True` if the move should be accepted and `False` if it should be rejected. Plot the new configuration of your system using the following cell and comment in whether the move was accepted or rejected (note that this updates the original plotting of the cell so you need to scroll up to observe the change). "
+    "This returns `True` if the move should be accepted and `False` if it should be rejected. An accepted move is applied to the system with `apply`; a rejected proposal is simply dropped, and the system is unchanged. Run the following cell and comment on whether the move was accepted or rejected (note that this updates the original plotting of the cell so you need to scroll up to observe the change)."
    ]
   },
   {
@@ -314,6 +315,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "if accepted:\n",
+    "    simulation.apply(proposal)\n",
     "sample_system.update(simulation)"
    ]
   },
@@ -321,19 +324,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Accept and reject\n",
+    "### Build the loop\n",
     "\n",
-    "pylj also has functions built in to accept and reject the moves that are proposed. These take the following forms, \n",
+    "A Monte Carlo step is therefore: propose a move, decide with the Metropolis condition, and apply the move if it was accepted.\n",
     "\n",
     "```python\n",
     "\n",
-    "accept()\n",
-    "\n",
-    "reject()\n",
+    "proposal = simulation.propose()\n",
+    "if mc.accept(proposal.energy_change, temperature):\n",
+    "    simulation.apply(proposal)\n",
     "\n",
     "```\n",
     "\n",
-    "Using this knowledge, attempt to build you own Monte Carlo simulation loop, using the `update` to present the changes to the simulation visualisation (note that this is the slowest part of the computation so it is recommended that you don't perform this every iteration). "
+    "Using this knowledge, attempt to build your own Monte Carlo simulation loop, using the `update` to present the changes to the simulation visualisation (note that this is the slowest part of the computation so it is recommended that you don't perform this every iteration)."
    ]
   },
   {

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -78,7 +78,7 @@ def initialise(
     ------
     ValueError
         If the temperature or the placement temperature is not positive and
-        finite, a species' pair energy has not died away at the cut-off,
+        finite, a pair potential's energy has not died away at the cut-off,
         Metropolis placement exhausts its trial budget, or the initial
         configuration is not finite or stores more than
         ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle.

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -114,7 +114,7 @@ def accept(
     Args:
         energy_change: The energy of the proposed configuration minus that
             of the current one, in joules.
-        temperature: Temperature of the simulation, in kelvin.
+        temperature: The temperature the acceptance is judged at, in kelvin.
         random_number: The uniform random number the acceptance probability
             is tested against. By default one is drawn from ``rng``.
         rng: The generator to draw from; pass the system's ``rng`` for a

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -77,11 +77,9 @@ def initialise(
     Raises
     ------
     ValueError
-        If the temperature or the placement temperature is not positive and
-        finite, a pair potential's energy has not died away at the cut-off,
-        Metropolis placement exhausts its trial budget, or the initial
-        configuration is not finite or stores more than
-        ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle.
+        If the initial configuration is not finite or stores more than
+        ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle;
+        and anything :class:`util.System` raises at construction.
     """
     from pylj import util
 
@@ -96,7 +94,7 @@ def initialise(
         placement_temperature=placement_temperature,
         seed=seed,
     )
-    util.check_initial_energy(system, system.energy)
+    util.check_initial_energy(system)
     return system
 
 
@@ -127,7 +125,15 @@ def accept(
 
     Returns:
         True if the proposed configuration should be accepted.
+
+    Raises:
+        ValueError: If ``energy_change`` is NaN.
     """
+    if np.isnan(energy_change):
+        raise ValueError(
+            "The energy change is NaN; check the pair potential's energies for a division "
+            "by zero or an invalid parameter."
+        )
     if energy_change <= 0:
         return True
     if random_number is None:

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -33,10 +33,11 @@ def initialise(
     *,
     species,
     pair_potentials,
+    placement_temperature=None,
     seed=None,
 ):
-    """Initialise the particle positions (square or random arrangement) and
-    calculate the initial pair energies and their total.
+    """Initialise the particle positions (square lattice or Metropolis
+    insertion) and calculate the initial pair energies and their total.
 
     Parameters
     ----------
@@ -48,10 +49,9 @@ def initialise(
         Length of a single dimension of the simulation square, in Angstrom.
     init_conf: string
         The way that the particles are initially positioned. Should be one of:
-        - 'square'
-        - 'random'
-        Both raise ``ValueError`` if the particles cannot be placed without
-        their repulsive cores overlapping.
+        - 'square', a square lattice
+        - 'metropolis', sequential Metropolis insertion at
+          ``placement_temperature``
     species: sequence of Species
         Required, keyword only. The species in the system; particles are
         assigned to them in turn.
@@ -60,6 +60,11 @@ def initialise(
         species, including each species with itself. Only the pair energies
         are evaluated, so a potential with no finite force, such as the
         square well, can be used.
+    placement_temperature: float (optional)
+        Temperature, in kelvin, of the Metropolis acceptance used by
+        ``init_conf='metropolis'``; by default the run temperature. A
+        parameter of the placement, not a thermodynamic temperature: raising
+        it tolerates more overlap, lowering it packs more tightly.
     seed: int (optional)
         Seed for the random number generator used to place a random initial
         configuration and make the Monte Carlo moves. The same seed
@@ -80,6 +85,7 @@ def initialise(
         pair_potentials=pair_potentials,
         simulation="mc",
         init_conf=init_conf,
+        placement_temperature=placement_temperature,
         seed=seed,
     )
     return system

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -77,9 +77,7 @@ def initialise(
     Raises
     ------
     ValueError
-        If the initial configuration is not finite or stores more than
-        ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle;
-        and anything :class:`util.System` raises at construction.
+        Whatever :class:`util.System` rejects at construction.
     """
     from pylj import util
 
@@ -94,7 +92,6 @@ def initialise(
         placement_temperature=placement_temperature,
         seed=seed,
     )
-    util.check_initial_energy(system)
     return system
 
 
@@ -125,15 +122,7 @@ def accept(
 
     Returns:
         True if the proposed configuration should be accepted.
-
-    Raises:
-        ValueError: If ``energy_change`` is NaN.
     """
-    if np.isnan(energy_change):
-        raise ValueError(
-            "The energy change is NaN; check the pair potential's energies for a division "
-            "by zero or an invalid parameter."
-        )
     if energy_change <= 0:
         return True
     if random_number is None:

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -66,7 +66,7 @@ def initialise(
         parameter of the placement, not a thermodynamic temperature: raising
         it tolerates more overlap, lowering it packs more tightly.
     seed: int (optional)
-        Seed for the random number generator used to place a random initial
+        Seed for the random number generator used to place an initial
         configuration and make the Monte Carlo moves. The same seed
         reproduces the same run.
 

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -62,9 +62,8 @@ def initialise(
         square well, can be used.
     placement_temperature: float (optional)
         Temperature, in kelvin, of the Metropolis acceptance used by
-        ``init_conf='metropolis'``; by default the run temperature. A
-        parameter of the placement, not a thermodynamic temperature: raising
-        it tolerates more overlap, lowering it packs more tightly.
+        ``init_conf='metropolis'``; by default the run temperature. See
+        :class:`util.System`.
     seed: int (optional)
         Seed for the random number generator used to place an initial
         configuration and make the Monte Carlo moves. The same seed
@@ -78,8 +77,11 @@ def initialise(
     Raises
     ------
     ValueError
-        If the initial pair energy is not finite, as when particles of a
-        hard-core potential sit inside its diameter.
+        If the temperature or the placement temperature is not positive and
+        finite, a species' pair energy has not died away at the cut-off,
+        Metropolis placement exhausts its trial budget, or the initial
+        configuration is not finite or stores more than
+        ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle.
     """
     from pylj import util
 
@@ -94,11 +96,7 @@ def initialise(
         placement_temperature=placement_temperature,
         seed=seed,
     )
-    if not np.isfinite(system.energy):
-        raise ValueError(
-            "The initial pair energy is not finite: particles sit inside a hard core. "
-            "Use init_conf='metropolis', fewer particles or a larger box."
-        )
+    util.check_initial_energy(system, system.energy)
     return system
 
 

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -74,6 +74,12 @@ def initialise(
     -------
     System
         System information; ``energy`` is the total pair energy.
+
+    Raises
+    ------
+    ValueError
+        If the initial pair energy is not finite, as when particles of a
+        hard-core potential sit inside its diameter.
     """
     from pylj import util
 
@@ -88,6 +94,11 @@ def initialise(
         placement_temperature=placement_temperature,
         seed=seed,
     )
+    if not np.isfinite(system.energy):
+        raise ValueError(
+            "The initial pair energy is not finite: particles sit inside a hard core. "
+            "Use init_conf='metropolis', fewer particles or a larger box."
+        )
     return system
 
 

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -48,9 +48,8 @@ def initialise(
         species, including each species with itself.
     placement_temperature: float (optional)
         Temperature, in kelvin, of the Metropolis acceptance used by
-        ``init_conf='metropolis'``; by default the run temperature. A
-        parameter of the placement, not a thermodynamic temperature: raising
-        it tolerates more overlap, lowering it packs more tightly.
+        ``init_conf='metropolis'``; by default the run temperature. See
+        :class:`util.System`.
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     seed: int (optional)
@@ -66,10 +65,12 @@ def initialise(
     Raises
     ------
     ValueError
-        If fewer than two particles are requested, the temperature is not
-        positive, the initial pair energy is not finite, or the initial forces
-        would move a particle further than the box in one step, as they do when
-        particles overlap or the potential's parameters are in the wrong units.
+        If fewer than two particles are requested, the temperature or the
+        placement temperature is not positive and finite, a species' pair
+        energy has not died away at the cut-off, Metropolis placement
+        exhausts its trial budget, or the initial configuration is not finite
+        or stores more than ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential
+        energy per particle.
     """
     from pylj import util
 
@@ -98,19 +99,7 @@ def initialise(
     system.particles["yvelocity"] = v[:, 1]
     system.particles = heat_bath(system.particles, system.masses, temperature)
     system.compute_force()
-    if not np.all(np.isfinite(system.energies)):
-        raise ValueError(
-            "The initial pair energy is not finite: particles sit inside a hard core. "
-            "Use init_conf='metropolis', fewer particles or a larger box."
-        )
-    acceleration = np.hypot(system.particles["xacceleration"], system.particles["yacceleration"])
-    displacement = 0.5 * acceleration.max() * timestep_length**2
-    if displacement > system.box_length:
-        raise ValueError(
-            f"The initial forces would move a particle {displacement:.3g} m in one step, "
-            f"further than the {system.box_length:.3g} m box. Particles are overlapping, "
-            "or the potential's parameters are in the wrong units (metres and joules)."
-        )
+    util.check_initial_energy(system, float(system.energies.sum()))
     return system
 
 

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -65,11 +65,9 @@ def initialise(
     Raises
     ------
     ValueError
-        If fewer than two particles are requested, a pair potential has no
-        finite force (as the square well has not), or the initial
-        configuration is not finite or stores more than
-        ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle;
-        and anything :class:`util.System` raises at construction.
+        If fewer than two particles are requested or a pair potential has no
+        finite force (as the square well has not). See :class:`util.System`
+        for what construction rejects.
     """
     from pylj import util
 
@@ -98,7 +96,6 @@ def initialise(
     system.particles["yvelocity"] = v[:, 1]
     system.particles = heat_bath(system.particles, system.masses, temperature)
     system.compute_force()
-    util.check_initial_energy(system)
     return system
 
 

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -54,7 +54,7 @@ def initialise(
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     seed: int (optional)
-        Seed for the random number generator used to place a random initial
+        Seed for the random number generator used to place an initial
         configuration and draw the initial velocities. The same seed
         reproduces the same run.
 

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -65,7 +65,8 @@ def initialise(
     Raises
     ------
     ValueError
-        If fewer than two particles are requested, or the initial
+        If fewer than two particles are requested, a pair potential has no
+        finite force (as the square well has not), or the initial
         configuration is not finite or stores more than
         ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle;
         and anything :class:`util.System` raises at construction.

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -13,12 +13,13 @@ def initialise(
     *,
     species,
     pair_potentials,
+    placement_temperature=None,
     timestep_length=1e-14,
     seed=None,
 ):
-    """Initialise the particle positions (this can be either as a square or
-    random arrangement) and velocities (based on the temperature defined), and
-    calculate the initial forces/accelerations.
+    """Initialise the particle positions (this can be either as a square
+    lattice or by Metropolis insertion) and velocities (based on the
+    temperature defined), and calculate the initial forces/accelerations.
 
     Each velocity component is drawn from a normal (Gaussian) distribution
     with the thermal width for the particle's mass at the requested
@@ -36,16 +37,20 @@ def initialise(
         Length of a single dimension of the simulation square, in Angstrom.
     init_conf: string
         The way that the particles are initially positioned. Should be one of:
-        - 'square'
-        - 'random'
-        Both raise ``ValueError`` if the particles cannot be placed without
-        their repulsive cores overlapping.
+        - 'square', a square lattice
+        - 'metropolis', sequential Metropolis insertion at
+          ``placement_temperature``
     species: sequence of Species
         Required, keyword only. The species in the system; particles are
         assigned to them in turn.
     pair_potentials: mapping of (Species, Species) to PairPotential
         Required, keyword only. The potential acting between each pair of
         species, including each species with itself.
+    placement_temperature: float (optional)
+        Temperature, in kelvin, of the Metropolis acceptance used by
+        ``init_conf='metropolis'``; by default the run temperature. A
+        parameter of the placement, not a thermodynamic temperature: raising
+        it tolerates more overlap, lowering it packs more tightly.
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     seed: int (optional)
@@ -79,6 +84,7 @@ def initialise(
         pair_potentials=pair_potentials,
         simulation="md",
         init_conf=init_conf,
+        placement_temperature=placement_temperature,
         timestep_length=timestep_length,
         seed=seed,
     )

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -66,7 +66,7 @@ def initialise(
     ------
     ValueError
         If fewer than two particles are requested, the temperature or the
-        placement temperature is not positive and finite, a species' pair
+        placement temperature is not positive and finite, a pair potential's
         energy has not died away at the cut-off, Metropolis placement
         exhausts its trial budget, or the initial configuration is not finite
         or stores more than ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -66,8 +66,10 @@ def initialise(
     Raises
     ------
     ValueError
-        If fewer than two particles are requested, or the temperature is not
-        positive.
+        If fewer than two particles are requested, the temperature is not
+        positive, the initial pair energy is not finite, or the initial forces
+        would move a particle further than the box in one step, as they do when
+        particles overlap or the potential's parameters are in the wrong units.
     """
     from pylj import util
 
@@ -96,6 +98,19 @@ def initialise(
     system.particles["yvelocity"] = v[:, 1]
     system.particles = heat_bath(system.particles, system.masses, temperature)
     system.compute_force()
+    if not np.all(np.isfinite(system.energies)):
+        raise ValueError(
+            "The initial pair energy is not finite: particles sit inside a hard core. "
+            "Use init_conf='metropolis', fewer particles or a larger box."
+        )
+    acceleration = np.hypot(system.particles["xacceleration"], system.particles["yacceleration"])
+    displacement = 0.5 * acceleration.max() * timestep_length**2
+    if displacement > system.box_length:
+        raise ValueError(
+            f"The initial forces would move a particle {displacement:.3g} m in one step, "
+            f"further than the {system.box_length:.3g} m box. Particles are overlapping, "
+            "or the potential's parameters are in the wrong units (metres and joules)."
+        )
     return system
 
 

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -65,12 +65,10 @@ def initialise(
     Raises
     ------
     ValueError
-        If fewer than two particles are requested, the temperature or the
-        placement temperature is not positive and finite, a pair potential's
-        energy has not died away at the cut-off, Metropolis placement
-        exhausts its trial budget, or the initial configuration is not finite
-        or stores more than ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential
-        energy per particle.
+        If fewer than two particles are requested, or the initial
+        configuration is not finite or stores more than
+        ``util.INITIAL_ENERGY_LIMIT`` k_B T of potential energy per particle;
+        and anything :class:`util.System` raises at construction.
     """
     from pylj import util
 
@@ -99,7 +97,7 @@ def initialise(
     system.particles["yvelocity"] = v[:, 1]
     system.particles = heat_bath(system.particles, system.masses, temperature)
     system.compute_force()
-    util.check_initial_energy(system, float(system.energies.sum()))
+    util.check_initial_energy(system)
     return system
 
 

--- a/pylj/potentials.py
+++ b/pylj/potentials.py
@@ -65,11 +65,13 @@ class LennardJones(PairPotential):
 
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
-        return 4 * self.epsilon * (self.sigma**12 / dr**12 - self.sigma**6 / dr**6)
+        x = (self.sigma / dr) ** 6
+        return 4 * self.epsilon * x * (x - 1)
 
     def forces(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
-        return 4 * self.epsilon * (12 * self.sigma**12 / dr**13 - 6 * self.sigma**6 / dr**7)
+        x = (self.sigma / dr) ** 6
+        return 24 * self.epsilon * x * (2 * x - 1) / dr
 
 
 class Buckingham(PairPotential):

--- a/pylj/potentials.py
+++ b/pylj/potentials.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+from scipy.optimize import brentq
 
 
 @dataclass(frozen=True)
@@ -65,13 +66,15 @@ class LennardJones(PairPotential):
 
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
-        x = (self.sigma / dr) ** 6
+        with np.errstate(divide="ignore"):
+            x = (self.sigma / dr) ** 6
         return 4 * self.epsilon * x * (x - 1)
 
     def forces(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
-        x = (self.sigma / dr) ** 6
-        return 24 * self.epsilon * x * (2 * x - 1) / dr
+        with np.errstate(divide="ignore"):
+            x = (self.sigma / dr) ** 6
+            return 24 * self.epsilon * x * (2 * x - 1) / dr
 
 
 class Buckingham(PairPotential):
@@ -80,24 +83,53 @@ class Buckingham(PairPotential):
     .. math::
         E = A e^{-B r} - C / r^{6}
 
+    The form has a barrier at short range, inside which the dispersion term
+    wins and the energy falls to minus infinity. Inside the top of that
+    barrier, ``turnover``, the energy and force are taken as infinite: a
+    hard wall in place of the collapse.
+
     Args:
         a: The A parameter, an energy scale, in joules.
         b: The B parameter, an inverse length, in reciprocal metres.
         c: The C parameter, the dispersion coefficient, in joule metre^6.
+
+    Attributes:
+        turnover: The separation of the top of the short-range barrier, in
+            metres; zero when there is no barrier.
     """
 
     def __init__(self, *, a: float, b: float, c: float):
         self.a = a
         self.b = b
         self.c = c
+        self.turnover = self._find_turnover()
+
+    def _form(self, dr: NDArray[np.float64]) -> NDArray[np.float64]:
+        return self.a * np.exp(-self.b * dr) - self.c / dr**6
+
+    def _slope(self, dr: float) -> float:
+        return float(-self.a * self.b * np.exp(-self.b * dr) + 6 * self.c / dr**7)
+
+    def _find_turnover(self) -> float:
+        """Locate the top of the short-range barrier, where the slope is zero
+        between the collapse and the well."""
+        dr = np.geomspace(1e-13, 1e-8, 4000)
+        with np.errstate(over="ignore"):
+            barrier = int(np.argmax(self._form(dr)))
+        if barrier == 0:
+            return 0.0
+        return float(brentq(self._slope, dr[barrier - 1], dr[barrier + 1], xtol=1e-16))
 
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
-        return self.a * np.exp(-self.b * dr) - self.c / dr**6
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.where(dr < self.turnover, np.inf, self._form(dr))
 
     def forces(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
-        return self.a * self.b * np.exp(-self.b * dr) - 6 * self.c / dr**7
+        with np.errstate(divide="ignore", invalid="ignore"):
+            force = self.a * self.b * np.exp(-self.b * dr) - 6 * self.c / dr**7
+        return np.where(dr < self.turnover, np.inf, force)
 
 
 class SquareWell(PairPotential):

--- a/pylj/tests/argon.py
+++ b/pylj/tests/argon.py
@@ -6,7 +6,7 @@
 
 from typing import TypedDict
 
-from pylj.potentials import LennardJones, PairPotential, Species, SquareWell
+from pylj.potentials import Buckingham, LennardJones, PairPotential, Species, SquareWell
 
 
 class Model(TypedDict):
@@ -25,6 +25,12 @@ LJ_ARGON_LARGER = LennardJones(epsilon=1.577e-21, sigma=4.186e-10)
 ARGON_MODEL: Model = {
     "species": [ARGON],
     "pair_potentials": {(ARGON, ARGON): LJ_ARGON},
+}
+# A Buckingham form for argon, with its short-range barrier at 0.78 Angstrom.
+BUCKINGHAM_ARGON = Buckingham(a=1.69e-15, b=3.66e10, c=1.02e-77)
+BUCKINGHAM_MODEL: Model = {
+    "species": [ARGON],
+    "pair_potentials": {(ARGON, ARGON): BUCKINGHAM_ARGON},
 }
 # A hard-core square well with a 3 Angstrom core and a well out to 4.5.
 WELL = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)

--- a/pylj/tests/argon.py
+++ b/pylj/tests/argon.py
@@ -6,7 +6,7 @@
 
 from typing import TypedDict
 
-from pylj.potentials import LennardJones, PairPotential, Species
+from pylj.potentials import LennardJones, PairPotential, Species, SquareWell
 
 
 class Model(TypedDict):
@@ -26,6 +26,10 @@ ARGON_MODEL: Model = {
     "species": [ARGON],
     "pair_potentials": {(ARGON, ARGON): LJ_ARGON},
 }
+# A hard-core square well with a 3 Angstrom core and a well out to 4.5.
+WELL = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
+WELL_MODEL: Model = {"species": [ARGON], "pair_potentials": {(ARGON, ARGON): WELL}}
+
 MIXTURE_MODEL: Model = {
     "species": [ARGON, LARGER],
     "pair_potentials": {

--- a/pylj/tests/argon.py
+++ b/pylj/tests/argon.py
@@ -30,6 +30,16 @@ ARGON_MODEL: Model = {
 WELL = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
 WELL_MODEL: Model = {"species": [ARGON], "pair_potentials": {(ARGON, ARGON): WELL}}
 
+# Hard cores of three different diameters, one per species pair.
+WELL_MIXTURE_MODEL: Model = {
+    "species": [ARGON, LARGER],
+    "pair_potentials": {
+        (ARGON, ARGON): WELL,
+        (LARGER, LARGER): SquareWell(epsilon=1.5e-21, sigma=5e-10, lambda_=1.5),
+        (ARGON, LARGER): SquareWell(epsilon=1.5e-21, sigma=4e-10, lambda_=1.5),
+    },
+}
+
 MIXTURE_MODEL: Model = {
     "species": [ARGON, LARGER],
     "pair_potentials": {

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -51,6 +51,20 @@ class TestMc(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 mc.initialise(4, temperature, 8, "square", **ARGON_MODEL)
 
+    def test_initialise_refuses_a_lattice_inside_a_hard_core(self):
+        # 16 particles on a 4 by 4 lattice in a 10 Angstrom box are 2.5
+        # Angstrom apart, inside a 3 Angstrom hard core that the 5 Angstrom
+        # cut-off clears: the lattice energy is infinite.
+        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
+        with self.assertRaisesRegex(ValueError, "not finite"):
+            mc.initialise(
+                16, 300, 10, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
+            )
+
+    def test_initialise_refuses_an_overlapping_lattice(self):
+        with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
+            mc.initialise(16, 300, 10, "square", **ARGON_MODEL)
+
     def test_square_well_drives_monte_carlo(self):
         # Nine particles on a 3 by 3 lattice in a 12 Angstrom box: each has
         # four lattice neighbours 4 Angstrom away, inside the well, and four

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -50,17 +50,6 @@ class TestMc(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 mc.initialise(4, temperature, 8, "square", **ARGON_MODEL)
 
-    def test_initialise_refuses_a_lattice_inside_a_hard_core(self):
-        # 16 particles on a 4 by 4 lattice in a 10 Angstrom box are 2.5
-        # Angstrom apart, inside a 3 Angstrom hard core that the 5 Angstrom
-        # cut-off clears: the lattice energy is infinite.
-        with self.assertRaisesRegex(ValueError, "not finite"):
-            mc.initialise(16, 300, 10, "square", **WELL_MODEL)
-
-    def test_initialise_refuses_an_overlapping_lattice(self):
-        with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
-            mc.initialise(16, 300, 10, "square", **ARGON_MODEL)
-
     def test_square_well_drives_monte_carlo(self):
         # Nine particles on a 3 by 3 lattice in a 12 Angstrom box: each has
         # four lattice neighbours 4 Angstrom away, inside the well, and four
@@ -94,10 +83,6 @@ class TestMc(unittest.TestCase):
         a = mc.sample(300, a)
         assert_almost_equal(a.energy_sample, [300])
         assert_equal(a.step_sample, [5])
-
-    def test_accept_refuses_a_nan_energy_change(self):
-        with self.assertRaisesRegex(ValueError, "NaN"):
-            mc.accept(float("nan"), 300)
 
     def test_accept_takes_a_downhill_change_without_drawing(self):
         rng = np.random.default_rng(3)

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -5,8 +5,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, pairwise
 from pylj.constants import BOLTZMANN
-from pylj.potentials import SquareWell
-from pylj.tests.argon import ARGON, ARGON_MODEL, MIXTURE_MODEL
+from pylj.tests.argon import ARGON, ARGON_MODEL, MIXTURE_MODEL, WELL_MODEL
 
 
 def run_moves(system, steps):
@@ -55,11 +54,8 @@ class TestMc(unittest.TestCase):
         # 16 particles on a 4 by 4 lattice in a 10 Angstrom box are 2.5
         # Angstrom apart, inside a 3 Angstrom hard core that the 5 Angstrom
         # cut-off clears: the lattice energy is infinite.
-        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
         with self.assertRaisesRegex(ValueError, "not finite"):
-            mc.initialise(
-                16, 300, 10, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
-            )
+            mc.initialise(16, 300, 10, "square", **WELL_MODEL)
 
     def test_initialise_refuses_an_overlapping_lattice(self):
         with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
@@ -70,9 +66,7 @@ class TestMc(unittest.TestCase):
         # four lattice neighbours 4 Angstrom away, inside the well, and four
         # diagonal ones 5.66 Angstrom away, beyond it, so 18 pairs sit at
         # -epsilon. The cut-off, half the box, is 6 Angstrom.
-        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
-        model = {"species": [ARGON], "pair_potentials": {(ARGON, ARGON): well}}
-        system = mc.initialise(9, 300, 12, "square", seed=2, **model)
+        system = mc.initialise(9, 300, 12, "square", seed=2, **WELL_MODEL)
         assert_almost_equal(system.energy * 1e21, -27.0)
         overlaps = 0
         for _ in range(50):
@@ -100,6 +94,10 @@ class TestMc(unittest.TestCase):
         a = mc.sample(300, a)
         assert_almost_equal(a.energy_sample, [300])
         assert_equal(a.step_sample, [5])
+
+    def test_accept_refuses_a_nan_energy_change(self):
+        with self.assertRaisesRegex(ValueError, "NaN"):
+            mc.accept(float("nan"), 300)
 
     def test_accept_takes_a_downhill_change_without_drawing(self):
         rng = np.random.default_rng(3)

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -50,6 +50,10 @@ class TestMc(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 mc.initialise(4, temperature, 8, "square", **ARGON_MODEL)
 
+    def test_initialise_passes_the_placement_temperature_to_the_system(self):
+        a = mc.initialise(4, 100, 20, "metropolis", placement_temperature=50, **ARGON_MODEL)
+        self.assertEqual(a.placement_temperature, 50)
+
     def test_square_well_drives_monte_carlo(self):
         # Nine particles on a 3 by 3 lattice in a 12 Angstrom box: each has
         # four lattice neighbours 4 Angstrom away, inside the well, and four

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -188,7 +188,8 @@ class TestMc(unittest.TestCase):
 
     def test_seeded_runs_are_identical(self):
         def run(seed):
-            return run_moves(mc.initialise(16, 300, 30, "random", seed=seed, **ARGON_MODEL), 200)
+            system = mc.initialise(16, 300, 30, "metropolis", seed=seed, **ARGON_MODEL)
+            return run_moves(system, 200)
 
         first = run(7)
         second = run(7)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -58,6 +58,10 @@ class TestMd(unittest.TestCase):
             np.array_equal(first.particles["xvelocity"], other.particles["xvelocity"])
         )
 
+    def test_initialise_passes_the_placement_temperature_to_the_system(self):
+        a = md.initialise(4, 100, 20, "metropolis", placement_temperature=50, **ARGON_MODEL)
+        self.assertEqual(a.placement_temperature, 50)
+
     def test_initialise_one_particle_raises(self):
         with self.assertRaisesRegex(ValueError, "at least two particles"):
             md.initialise(1, 300, 8, "square", **ARGON_MODEL)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, md, pairwise
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
-from pylj.potentials import LennardJones, SquareWell
+from pylj.potentials import SquareWell
 from pylj.tests.argon import ARGON, ARGON_MODEL, MIXTURE_MODEL
 
 
@@ -44,29 +44,16 @@ class TestMd(unittest.TestCase):
         self.assertLess(abs(np.sum(a.masses * a.particles["yvelocity"])), 1e-12 * momentum_scale)
         assert_almost_equal(md.calculate_temperature(a.particles, a.masses), 100)
 
-    def test_initialise_refuses_parameters_in_the_wrong_units(self):
-        # Sigma given in Angstrom: every lattice pair sits deep inside the
-        # core, and the first step would throw a particle far beyond the box.
-        in_angstrom = LennardJones(epsilon=1.577e-21, sigma=3.372)
-        with self.assertRaisesRegex(ValueError, "wrong units"):
-            md.initialise(
-                4, 300, 30, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom}
-            )
-
-    def test_initialise_refuses_a_lattice_inside_a_hard_core(self):
-        # Four particles on a 2 by 2 lattice in a 4 Angstrom box are 2
-        # Angstrom apart, inside a 3 Angstrom hard core.
-        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
-        with self.assertRaisesRegex(ValueError, "not finite"):
-            mc.initialise(
-                4, 300, 4, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
-            )
-
-    def test_initialise_accepts_a_dense_but_finite_lattice(self):
+    def test_initialise_refuses_an_overlapping_lattice(self):
         # 16 argon on a 4 by 4 lattice in a 10 Angstrom box are 2.5 Angstrom
-        # apart, well inside sigma, but the first-step displacement is far
-        # less than the box: a silly start is allowed, a nonsensical one is not.
-        a = md.initialise(16, 300, 10, "square", **ARGON_MODEL)
+        # apart, inside sigma: about 90 k_B T of potential energy per particle.
+        with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
+            md.initialise(16, 300, 10, "square", **ARGON_MODEL)
+
+    def test_initialise_accepts_a_compressed_but_bound_lattice(self):
+        # 16 argon in a 14 Angstrom box are 3.5 Angstrom apart, just outside
+        # sigma, so the lattice is bound and starts.
+        a = md.initialise(16, 300, 14, "square", **ARGON_MODEL)
         assert_equal(a.number_of_particles, 16)
 
     def test_initialise_refuses_a_potential_with_no_force(self):

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -52,9 +52,9 @@ class TestMd(unittest.TestCase):
             )
 
     def test_initialise_is_reproducible_with_a_seed(self):
-        first = md.initialise(10, 100, 40, "random", seed=3, **ARGON_MODEL)
-        second = md.initialise(10, 100, 40, "random", seed=3, **ARGON_MODEL)
-        other = md.initialise(10, 100, 40, "random", seed=4, **ARGON_MODEL)
+        first = md.initialise(10, 100, 40, "metropolis", seed=3, **ARGON_MODEL)
+        second = md.initialise(10, 100, 40, "metropolis", seed=3, **ARGON_MODEL)
+        other = md.initialise(10, 100, 40, "metropolis", seed=4, **ARGON_MODEL)
         assert_equal(first.particles["xposition"], second.particles["xposition"])
         assert_equal(first.particles["xvelocity"], second.particles["xvelocity"])
         assert_equal(first.particles["yvelocity"], second.particles["yvelocity"])

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, md, pairwise
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
-from pylj.potentials import SquareWell
+from pylj.potentials import LennardJones, SquareWell
 from pylj.tests.argon import ARGON, ARGON_MODEL, MIXTURE_MODEL
 
 
@@ -43,6 +43,31 @@ class TestMd(unittest.TestCase):
         self.assertLess(abs(np.sum(a.masses * a.particles["xvelocity"])), 1e-12 * momentum_scale)
         self.assertLess(abs(np.sum(a.masses * a.particles["yvelocity"])), 1e-12 * momentum_scale)
         assert_almost_equal(md.calculate_temperature(a.particles, a.masses), 100)
+
+    def test_initialise_refuses_parameters_in_the_wrong_units(self):
+        # Sigma given in Angstrom: every lattice pair sits deep inside the
+        # core, and the first step would throw a particle far beyond the box.
+        in_angstrom = LennardJones(epsilon=1.577e-21, sigma=3.372)
+        with self.assertRaisesRegex(ValueError, "wrong units"):
+            md.initialise(
+                4, 300, 30, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom}
+            )
+
+    def test_initialise_refuses_a_lattice_inside_a_hard_core(self):
+        # Four particles on a 2 by 2 lattice in a 4 Angstrom box are 2
+        # Angstrom apart, inside a 3 Angstrom hard core.
+        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
+        with self.assertRaisesRegex(ValueError, "not finite"):
+            mc.initialise(
+                4, 300, 4, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
+            )
+
+    def test_initialise_accepts_a_dense_but_finite_lattice(self):
+        # 16 argon on a 4 by 4 lattice in a 10 Angstrom box are 2.5 Angstrom
+        # apart, well inside sigma, but the first-step displacement is far
+        # less than the box: a silly start is allowed, a nonsensical one is not.
+        a = md.initialise(16, 300, 10, "square", **ARGON_MODEL)
+        assert_equal(a.number_of_particles, 16)
 
     def test_initialise_refuses_a_potential_with_no_force(self):
         well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -5,8 +5,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, md, pairwise
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
-from pylj.potentials import SquareWell
-from pylj.tests.argon import ARGON, ARGON_MODEL, MIXTURE_MODEL
+from pylj.tests.argon import ARGON, ARGON_MODEL, MIXTURE_MODEL, WELL_MODEL
 
 
 class TestMd(unittest.TestCase):
@@ -57,11 +56,8 @@ class TestMd(unittest.TestCase):
         assert_equal(a.number_of_particles, 16)
 
     def test_initialise_refuses_a_potential_with_no_force(self):
-        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
         with self.assertRaisesRegex(ValueError, "Monte Carlo"):
-            md.initialise(
-                2, 300, 8, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
-            )
+            md.initialise(2, 300, 8, "square", **WELL_MODEL)
 
     def test_initialise_is_reproducible_with_a_seed(self):
         first = md.initialise(10, 100, 40, "metropolis", seed=3, **ARGON_MODEL)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -43,24 +43,6 @@ class TestMd(unittest.TestCase):
         self.assertLess(abs(np.sum(a.masses * a.particles["yvelocity"])), 1e-12 * momentum_scale)
         assert_almost_equal(md.calculate_temperature(a.particles, a.masses), 100)
 
-    def test_initialise_refuses_an_overlapping_lattice(self):
-        # 16 argon on a 4 by 4 lattice in a 10 Angstrom box are 2.5 Angstrom
-        # apart, inside sigma: about 90 k_B T of potential energy per particle.
-        with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
-            md.initialise(16, 300, 10, "square", **ARGON_MODEL)
-
-    def test_initialise_accepts_a_lattice_below_the_energy_limit(self):
-        # 16 argon in a 12 Angstrom box store about 5.6 k_B T per particle
-        # at 300 K, under the limit of 10, and construct.
-        a = md.initialise(16, 300, 12, "square", **ARGON_MODEL)
-        assert_equal(a.number_of_particles, 16)
-
-    def test_initialise_accepts_a_compressed_but_bound_lattice(self):
-        # 16 argon in a 14 Angstrom box are 3.5 Angstrom apart, just outside
-        # sigma, so the lattice is bound and starts.
-        a = md.initialise(16, 300, 14, "square", **ARGON_MODEL)
-        assert_equal(a.number_of_particles, 16)
-
     def test_initialise_refuses_a_potential_with_no_force(self):
         with self.assertRaisesRegex(ValueError, "Monte Carlo"):
             md.initialise(2, 300, 8, "square", **WELL_MODEL)

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -49,6 +49,12 @@ class TestMd(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
             md.initialise(16, 300, 10, "square", **ARGON_MODEL)
 
+    def test_initialise_accepts_a_lattice_below_the_energy_limit(self):
+        # 16 argon in a 12 Angstrom box store about 5.6 k_B T per particle
+        # at 300 K, under the limit of 10, and construct.
+        a = md.initialise(16, 300, 12, "square", **ARGON_MODEL)
+        assert_equal(a.number_of_particles, 16)
+
     def test_initialise_accepts_a_compressed_but_bound_lattice(self):
         # 16 argon in a 14 Angstrom box are 3.5 Angstrom apart, just outside
         # sigma, so the lattice is bound and starts.

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -217,14 +217,13 @@ class TestPairwise(unittest.TestCase):
     def test_compute_energy_needs_no_force_from_the_potential(self):
         # The square well has no finite force, so it drives the energy path
         # only.
-        well = WELL
         particles = three_particles([0, 0, 0])
-        _, energies = pairwise.compute_energy(particles, 30, 15, {(ARGON, ARGON): well}, [ARGON])
+        _, energies = pairwise.compute_energy(particles, 30, 15, {(ARGON, ARGON): WELL}, [ARGON])
         # (0, 1) at 4 Angstrom is in the well; (0, 2) at 5.1 and (1, 2) at
         # 7.07 are beyond it.
         assert_almost_equal(energies * 1e21, [-1.5, 0.0, 0.0])
         with pytest.raises(ValueError, match="Monte Carlo"):
-            pairwise.compute_force(particles, 30, 15, {(ARGON, ARGON): well}, [ARGON])
+            pairwise.compute_force(particles, 30, 15, {(ARGON, ARGON): WELL}, [ARGON])
 
     def test_particle_energy_sums_the_pairs(self):
         # Neighbours 4 and 5 Angstrom from the origin, both argon.

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_almost_equal
 
 from pylj import pairwise, util
 from pylj.constants import ATOMIC_MASS_UNIT
-from pylj.potentials import PairPotential, Species, SquareWell
+from pylj.potentials import PairPotential, Species
 from pylj.tests.argon import (
     ARGON,
     ARGON_MODEL,
@@ -15,6 +15,7 @@ from pylj.tests.argon import (
     LJ_ARGON,
     LJ_ARGON_LARGER,
     MIXTURE_MODEL,
+    WELL,
 )
 
 
@@ -216,7 +217,7 @@ class TestPairwise(unittest.TestCase):
     def test_compute_energy_needs_no_force_from_the_potential(self):
         # The square well has no finite force, so it drives the energy path
         # only.
-        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
+        well = WELL
         particles = three_particles([0, 0, 0])
         _, energies = pairwise.compute_energy(particles, 30, 15, {(ARGON, ARGON): well}, [ARGON])
         # (0, 1) at 4 Angstrom is in the well; (0, 2) at 5.1 and (1, 2) at

--- a/pylj/tests/test_potentials.py
+++ b/pylj/tests/test_potentials.py
@@ -77,6 +77,13 @@ class TestLennardJones:
         assert lj.energies(np.array([3e-10, 4e-10])).shape == (2,)
         assert lj.forces(np.array([3e-10, 4e-10])).shape == (2,)
 
+    def test_is_infinite_at_zero_separation(self):
+        # Coincident particles cost infinite energy, so a Metropolis trial
+        # there is rejected rather than compared as NaN.
+        lj = LennardJones(epsilon=1.65e-21, sigma=3.4e-10)
+        assert lj.energies(np.array([0.0]))[0] == np.inf
+        assert lj.forces(np.array([0.0]))[0] == np.inf
+
 
 class TestBuckingham:
     def test_constructor_is_keyword_only(self):
@@ -95,6 +102,28 @@ class TestBuckingham:
         h = r * 1e-6
         numerical = -(bk.energies(r + h) - bk.energies(r - h)) / (2 * h)
         np.testing.assert_allclose(bk.forces(r), numerical, rtol=1e-4)
+
+    def test_turnover_is_the_top_of_the_barrier(self):
+        bk = Buckingham(a=1e-16, b=3e10, c=1e-77)
+        r = bk.turnover
+        assert 0 < r < 3e-10
+        # Zero to the root finder's tolerance, against a force scale of A B.
+        np.testing.assert_allclose(bk.forces(np.array([r])), [0.0], atol=1e-6 * 1e-16 * 3e10)
+        assert bk.energies(np.array([0.99 * r]))[0] == np.inf
+        assert bk.energies(np.array([1.01 * r]))[0] < bk.energies(np.array([r]))[0]
+
+    def test_is_infinite_inside_the_turnover(self):
+        # The form collapses to minus infinity at short range; inside the
+        # barrier the potential is a hard wall instead.
+        bk = Buckingham(a=1e-16, b=3e10, c=1e-77)
+        inside = np.array([0.0, 0.5 * bk.turnover])
+        assert np.all(bk.energies(inside) == np.inf)
+        assert np.all(bk.forces(inside) == np.inf)
+
+    def test_a_form_without_a_barrier_has_no_wall(self):
+        bk = Buckingham(a=1e-16, b=3e10, c=0.0)
+        assert bk.turnover == 0.0
+        assert np.isfinite(bk.energies(np.array([1e-12]))[0])
 
 
 class TestSquareWell:

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -35,7 +35,7 @@ from pylj.sample.panes import (
     TemperaturePane,
     _fit_axes,
 )
-from pylj.tests.argon import ARGON, ARGON_MODEL, LJ_ARGON, MIXTURE_MODEL, WELL
+from pylj.tests.argon import ARGON, ARGON_MODEL, LJ_ARGON, MIXTURE_MODEL, WELL, WELL_MODEL
 
 NAMED_VIEWERS = [JustCell, Energy, MaxBolt, RDF, Interactions, Phase, Scattering]
 
@@ -182,14 +182,11 @@ def test_cell_pane_takes_one_diameter_per_species():
 def test_cell_pane_default_diameter_for_a_square_well_is_the_hard_core():
     # The square-well energy steps from an infinite core through the well to
     # zero, so the default drawn diameter is the hard-core diameter sigma.
-    well = WELL
-    system = mc.initialise(
-        4, 100, 20, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
-    )
+    system = mc.initialise(4, 100, 20, "square", **WELL_MODEL)
     fig, ax = environment(1)
     pane = CellPane()
     pane.setup(ax, system)
-    assert_allclose(pane.diameters, [3e-10], rtol=2e-3)
+    assert_allclose(pane.diameters, [WELL.sigma], rtol=2e-3)
     plt.close(fig)
 
 

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 
 from pylj import mc, md
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
-from pylj.potentials import PairPotential, SquareWell
+from pylj.potentials import PairPotential
 from pylj.sample import (
     RDF,
     CellPlus,
@@ -35,7 +35,7 @@ from pylj.sample.panes import (
     TemperaturePane,
     _fit_axes,
 )
-from pylj.tests.argon import ARGON, ARGON_MODEL, LJ_ARGON, MIXTURE_MODEL
+from pylj.tests.argon import ARGON, ARGON_MODEL, LJ_ARGON, MIXTURE_MODEL, WELL
 
 NAMED_VIEWERS = [JustCell, Energy, MaxBolt, RDF, Interactions, Phase, Scattering]
 
@@ -182,7 +182,7 @@ def test_cell_pane_takes_one_diameter_per_species():
 def test_cell_pane_default_diameter_for_a_square_well_is_the_hard_core():
     # The square-well energy steps from an infinite core through the well to
     # zero, so the default drawn diameter is the hard-core diameter sigma.
-    well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
+    well = WELL
     system = mc.initialise(
         4, 100, 20, "square", species=[ARGON], pair_potentials={(ARGON, ARGON): well}
     )

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -214,11 +214,11 @@ def test_cell_pane_default_needs_a_potential_minimum():
     class Unbounded(PairPotential):
         def energies(self, dr):
             dr = np.asarray(dr, dtype=float)
-            return 1e-21 * ((3e-10 / dr) ** 12 - dr / 3e-10)
+            return 1e-21 * ((3e-10 / dr) ** 12 - 1e-3 * dr / 3e-10)
 
         def forces(self, dr):
             dr = np.asarray(dr, dtype=float)
-            return 1e-21 * (12 * (3e-10 / dr) ** 12 / dr + 1 / 3e-10)
+            return 1e-21 * (12 * (3e-10 / dr) ** 12 / dr + 1e-3 / 3e-10)
 
     model = {"species": [ARGON], "pair_potentials": {(ARGON, ARGON): Unbounded()}}
     system = md.initialise(4, 100, 20, "square", **model)

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -295,8 +295,8 @@ def test_energy_pane_mc_plots_against_step():
     plt.close(fig)
 
 
-def test_rdf_pane_normalisation_is_unity_for_random_positions():
-    system = md.initialise(400, 100, 100, "random", seed=1, **ARGON_MODEL)
+def test_rdf_pane_normalisation_is_unity_for_metropolis_positions():
+    system = md.initialise(400, 100, 100, "metropolis", seed=1, **ARGON_MODEL)
     fig, ax = environment(1)
     pane = RDFPane()
     pane.setup(ax, system)

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -71,6 +71,14 @@ class TestUtil(unittest.TestCase):
                 simulation="md",
             )
 
+    def test_system_refuses_a_cross_potential_still_repulsive_at_the_cut_off(self):
+        mistyped = dict(MIXTURE_MODEL["pair_potentials"])
+        mistyped[(ARGON, LARGER)] = LennardJones(epsilon=1.577e-21, sigma=4.186)
+        with self.assertRaisesRegex(ValueError, "between argon and larger"):
+            util.System(
+                4, 100, 60, species=[ARGON, LARGER], pair_potentials=mistyped, simulation="md"
+            )
+
     def test_system_metropolis_configuration_has_no_overlap(self):
         # At 100 K a pair inside 0.8 sigma costs over 40 well depths and is
         # never accepted, so the closest pair sits outside the core.

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -1,30 +1,11 @@
-import itertools
-import re
 import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from pylj import mc, md, util
-from pylj.potentials import Buckingham, LennardJones, PairPotential, SquareWell
+from pylj import mc, md, pairwise, util
+from pylj.potentials import LennardJones
 from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL
-
-
-def minimum_image_distances(system):
-    """Return the minimum-image separation, in metres, for every pair of
-    particles in ``system``."""
-    box_length = system.box_length
-    x = system.particles["xposition"]
-    y = system.particles["yposition"]
-    distances = []
-    for i in range(system.number_of_particles):
-        for j in range(i + 1, system.number_of_particles):
-            dx = x[i] - x[j]
-            dy = y[i] - y[j]
-            dx -= box_length * np.round(dx / box_length)
-            dy -= box_length * np.round(dy / box_length)
-            distances.append(np.sqrt(dx**2 + dy**2))
-    return distances
 
 
 class TestUtil(unittest.TestCase):
@@ -43,89 +24,84 @@ class TestUtil(unittest.TestCase):
         assert_equal(a.forces.size, 1)
         assert_equal(a.energies.size, 1)
 
-    def test_system_random(self):
-        a = util.System(2, 300, 8, init_conf="random", simulation="md", **ARGON_MODEL)
+    def test_system_metropolis(self):
+        a = util.System(2, 300, 8, init_conf="metropolis", simulation="md", **ARGON_MODEL)
         assert_equal(a.number_of_particles, 2)
-        assert_equal(a.temperature, 300)
-        assert_almost_equal(a.box_length * 1e10, 8)
-        assert_almost_equal(a.timestep_length, 1e-14)
-        self.assertTrue(0 <= a.particles["xposition"][0] * 1e10 <= 8)
-        self.assertTrue(0 <= a.particles["yposition"][0] * 1e10 <= 8)
-        self.assertTrue(0 <= a.particles["xposition"][1] * 1e10 <= 8)
-        self.assertTrue(0 <= a.particles["yposition"][1] * 1e10 <= 8)
+        for axis in ("xposition", "yposition"):
+            self.assertTrue(np.all((0 <= a.particles[axis]) & (a.particles[axis] < a.box_length)))
         assert_almost_equal(a.cut_off * 1e10, 4.0)
         assert_equal(a.distances.size, 1)
-        assert_equal(a.forces.size, 1)
-        assert_equal(a.energies.size, 1)
 
-    def test_system_random_no_overlap(self):
-        a = util.System(30, 100, 40, init_conf="random", simulation="md", seed=0, **ARGON_MODEL)
-        for distance in minimum_image_distances(a):
-            self.assertTrue(distance >= a.cores[0])
-
-    def test_system_random_too_dense_raises(self):
-        with self.assertRaisesRegex(ValueError, "after 1000 attempts"):
-            util.System(200, 100, 20, init_conf="random", simulation="md", **ARGON_MODEL)
-
-    def test_system_square_overlap_message_for_one_particle(self):
-        with self.assertRaisesRegex(ValueError, "1 particle fits"):
-            util.System(5, 100, 4, simulation="md", **ARGON_MODEL)
-
-    def test_system_square_overlap_raises(self):
-        # 50 argon particles in a 20 Angstrom box: at most 25 fit on a
-        # square lattice without overlap.
-        with self.assertRaisesRegex(ValueError, "at most 25 particles"):
-            util.System(50, 100, 20, simulation="md", **ARGON_MODEL)
-
-    def test_system_square_between_core_and_diameter_is_accepted(self):
-        # 101 argon particles in a 40 Angstrom box space 3.64 Angstrom apart,
-        # above the 3.37 Angstrom repulsive core.
-        a = util.System(101, 100, 40, simulation="md", **ARGON_MODEL)
-        assert_equal(a.number_of_particles, 101)
-
-    def test_system_random_threshold_is_the_core(self):
-        # With seed 4 particles land closer together than 8 Angstrom but
-        # still respect the 3.37 Angstrom repulsive core.
-        a = util.System(10, 100, 30, init_conf="random", simulation="md", seed=4, **ARGON_MODEL)
-        distances = minimum_image_distances(a)
-        self.assertTrue(all(distance >= a.cores[0] for distance in distances))
-        self.assertTrue(any(distance < 8e-10 for distance in distances))
-
-    def test_system_random_two_types_uses_the_mean_of_the_pair_cores(self):
-        a = util.System(12, 100, 60, init_conf="random", simulation="md", seed=5, **MIXTURE_MODEL)
-        types = a.particles["types"]
-        distances = minimum_image_distances(a)
-        pairs = itertools.combinations(range(a.number_of_particles), 2)
-        for distance, (i, j) in zip(distances, pairs, strict=True):
-            type_i, type_j = int(types[i]), int(types[j])
-            min_separation = (a.cores[type_i] + a.cores[type_j]) / 2
-            self.assertTrue(distance >= min_separation)
-
-    def test_system_argon_core_equals_sigma(self):
-        a = util.System(2, 300, 8, simulation="md", **ARGON_MODEL)
-        assert_almost_equal(a.cores[0] * 1e10, LJ_ARGON.sigma * 1e10, decimal=3)
-
-    def test_system_square_well_core_is_at_least_sigma(self):
-        sigma = 1.5e-10
-        well = SquareWell(epsilon=1.0, sigma=sigma, lambda_=2.0)
-        b = util.System(
-            2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): well}, simulation="md"
+    def test_system_metropolis_configuration_has_no_overlap(self):
+        # At 100 K a pair inside 0.8 sigma costs over 40 well depths and is
+        # never accepted, so the closest pair sits outside the core.
+        a = util.System(30, 100, 40, init_conf="metropolis", simulation="md", seed=0, **ARGON_MODEL)
+        distances, _ = pairwise.compute_energy(
+            a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
         )
-        self.assertTrue(sigma <= b.cores[0] <= sigma * 1.002)
+        self.assertGreater(distances.min(), 0.8 * LJ_ARGON.sigma)
 
-    def test_system_potential_never_positive_raises(self):
-        class NeverPositive(PairPotential):
-            def energies(self, dr):
-                return -np.ones_like(np.asarray(dr, dtype=float))
+    def test_system_metropolis_too_dense_raises(self):
+        with self.assertRaisesRegex(ValueError, "after 1000 attempts"):
+            util.System(200, 100, 20, init_conf="metropolis", simulation="md", **ARGON_MODEL)
 
-            def forces(self, dr):
-                return np.zeros_like(np.asarray(dr, dtype=float))
-
-        with self.assertRaisesRegex(ValueError, "repulsive core"):
-            util.System(
-                2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): NeverPositive()},
-                simulation="md",
+    def test_system_metropolis_seed_reproduces_placement(self):
+        def build(seed):
+            return util.System(
+                10, 100, 40, init_conf="metropolis", simulation="md", seed=seed, **ARGON_MODEL
             )
+
+        first = build(3)
+        second = build(3)
+        other = build(4)
+        assert_equal(first.particles["xposition"], second.particles["xposition"])
+        assert_equal(first.particles["yposition"], second.particles["yposition"])
+        self.assertFalse(
+            np.array_equal(first.particles["xposition"], other.particles["xposition"])
+        )
+
+    def test_system_metropolis_seed_is_not_taken_from_the_global_state(self):
+        def build():
+            return util.System(
+                10, 100, 40, init_conf="metropolis", simulation="md", seed=3, **ARGON_MODEL
+            )
+
+        first = build()
+        state = np.random.get_state()
+        try:
+            np.random.seed(99)
+            second = build()
+        finally:
+            np.random.set_state(state)
+        assert_equal(first.particles["xposition"], second.particles["xposition"])
+
+    def test_system_metropolis_defaults_placement_temperature_to_the_run_temperature(self):
+        default = util.System(2, 300, 8, simulation="md", **ARGON_MODEL)
+        explicit = util.System(
+            2, 300, 8, simulation="md", placement_temperature=1000, **ARGON_MODEL
+        )
+        self.assertEqual(default.placement_temperature, 300)
+        self.assertEqual(explicit.placement_temperature, 1000)
+
+    def test_system_rejects_a_bad_placement_temperature(self):
+        for bad in (0, -1, np.inf):
+            with self.assertRaisesRegex(ValueError, "placement_temperature must be positive"):
+                util.System(2, 300, 8, simulation="md", placement_temperature=bad, **ARGON_MODEL)
+
+    def test_system_metropolis_placement_temperature_governs_success(self):
+        # 50 argon particles in a 25 Angstrom box: as near-hard discs of
+        # diameter sigma (placement at 1 K) they exceed the packing that
+        # sequential insertion reaches, but at 1e5 K overlaps are tolerated.
+        with self.assertRaises(ValueError):
+            util.System(
+                50, 100, 25, init_conf="metropolis", simulation="md", seed=0,
+                placement_temperature=1.0, **ARGON_MODEL,
+            )
+        hot = util.System(
+            50, 100, 25, init_conf="metropolis", simulation="md", seed=0,
+            placement_temperature=1e5, **ARGON_MODEL,
+        )
+        assert_equal(hot.number_of_particles, 50)
 
     def test_system_too_big(self):
         with self.assertRaises(AttributeError) as context:
@@ -150,7 +126,7 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(
             "The initial configuration type horseradish is not "
             "recognised. Available options are: square or "
-            "random" in str(context.exception)
+            "metropolis" in str(context.exception)
         )
 
     def test_system_records_simulation_kind(self):
@@ -211,68 +187,6 @@ class TestUtil(unittest.TestCase):
         self.assertIs(production.species, system.species)
         self.assertIs(production.pair_potentials, system.pair_potentials)
         assert_equal(production.masses, system.masses)
-
-    def test_system_square_too_small_box_suggests_a_box_that_fits(self):
-        for number_of_particles in (2, 7, 50):
-            with self.assertRaises(ValueError) as context:
-                util.System(number_of_particles, 100, 4, simulation="md", **ARGON_MODEL)
-            match = re.search(r"at least ([0-9.]+) Angstrom fits", str(context.exception))
-            self.assertIsNotNone(match)
-            suggested_box = float(match.group(1))
-            a = util.System(
-                number_of_particles, 100, suggested_box, simulation="md", **ARGON_MODEL
-            )
-            self.assertEqual(a.number_of_particles, number_of_particles)
-
-    def test_system_potential_energies_returning_a_scalar_is_rejected(self):
-        class ScalarEnergy(PairPotential):
-            def energies(self, dr):
-                return 1.0
-
-            def forces(self, dr):
-                return 0.0
-
-        with self.assertRaisesRegex(ValueError, "one value per separation"):
-            util.System(
-                2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): ScalarEnergy()},
-                simulation="md",
-            )
-
-    def test_system_potential_energies_returning_the_wrong_shape_is_rejected(self):
-        class ShortEnergy(PairPotential):
-            def energies(self, dr):
-                return np.ones(3)
-
-            def forces(self, dr):
-                return np.zeros(3)
-
-        with self.assertRaisesRegex(ValueError, "one value per separation"):
-            util.System(
-                2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): ShortEnergy()},
-                simulation="md",
-            )
-
-    def test_system_potential_positive_at_50_angstrom_names_units(self):
-        # Sigma given in Angstrom rather than metres: the pair energy never
-        # falls to zero on the 0.1 to 50 Angstrom grid.
-        in_angstrom = LennardJones(epsilon=1.58e-21, sigma=3.4)
-        with self.assertRaisesRegex(ValueError, "still positive at 50 Angstrom"):
-            util.System(
-                2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom},
-                simulation="md",
-            )
-
-    def test_system_random_buckingham_core_energy_is_near_zero(self):
-        potential = Buckingham(a=1.69e-15, b=3.66e10, c=1.01e-77)
-        a = util.System(
-            10, 100, 40, init_conf="random", species=[ARGON],
-            pair_potentials={(ARGON, ARGON): potential}, simulation="md", seed=0,
-        )
-        self.assertTrue(a.cores[0] > 3e-10)
-        r = np.logspace(-11, np.log10(5e-9), 4000)
-        well_depth = potential.energies(r).min()
-        core_energy = potential.energies(np.array([a.cores[0]]))[0]
-        self.assertTrue(abs(core_energy) < 1e-3 * abs(well_depth))
 
     def test_restart_starts_a_fresh_record_from_the_current_state(self):
         system = md.initialise(4, 300, 12, "square", **ARGON_MODEL)
@@ -336,38 +250,6 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(production.energy, system.energy)
         self.assertEqual(production.energy_sample.size, 0)
         self.assertEqual(system.energy_sample.size, 1)
-
-    def test_system_seed_reproduces_random_placement(self):
-        def build(seed):
-            return util.System(
-                10, 100, 40, init_conf="random", simulation="md", seed=seed, **ARGON_MODEL
-            )
-
-        first = build(3)
-        second = build(3)
-        other = build(4)
-        assert_equal(first.particles["xposition"], second.particles["xposition"])
-        assert_equal(first.particles["yposition"], second.particles["yposition"])
-        self.assertFalse(
-            np.array_equal(first.particles["xposition"], other.particles["xposition"])
-        )
-
-    def test_system_seed_is_not_taken_from_the_global_state(self):
-        # Two systems built with the same seed agree even when the global
-        # NumPy state differs between them.
-        def build():
-            return util.System(
-                10, 100, 40, init_conf="random", simulation="md", seed=3, **ARGON_MODEL
-            )
-
-        first = build()
-        state = np.random.get_state()
-        try:
-            np.random.seed(99)
-            second = build()
-        finally:
-            np.random.set_state(state)
-        assert_equal(first.particles["xposition"], second.particles["xposition"])
 
     def test_restart_copies_the_generator_state(self):
         system = md.initialise(4, 300, 12, "square", seed=1, **ARGON_MODEL)

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -4,8 +4,8 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, md, pairwise, util
-from pylj.potentials import LennardJones
-from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL
+from pylj.potentials import LennardJones, SquareWell
+from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, LJ_LARGER, MIXTURE_MODEL
 
 
 class TestUtil(unittest.TestCase):
@@ -31,6 +31,33 @@ class TestUtil(unittest.TestCase):
             self.assertTrue(np.all((0 <= a.particles[axis]) & (a.particles[axis] < a.box_length)))
         assert_almost_equal(a.cut_off * 1e10, 4.0)
         assert_equal(a.distances.size, 1)
+
+    def test_system_metropolis_places_a_hard_core_outside_its_diameter(self):
+        # A trial inside the square well's core costs infinite energy and is
+        # always rejected, so no pair is closer than sigma.
+        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
+        a = util.System(
+            50, 300, 30, init_conf="metropolis", simulation="mc", seed=1,
+            species=[ARGON], pair_potentials={(ARGON, ARGON): well},
+        )
+        distances, _ = pairwise.compute_energy(
+            a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
+        )
+        self.assertGreaterEqual(distances.min(), well.sigma)
+
+    def test_system_metropolis_places_a_mixture_with_each_pairs_own_potential(self):
+        # The larger species has a 5 Angstrom core; its pairs must respect
+        # that, not argon's 3.4 Angstrom one.
+        a = util.System(
+            20, 100, 60, init_conf="metropolis", simulation="md", seed=2, **MIXTURE_MODEL
+        )
+        distances, _ = pairwise.compute_energy(
+            a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
+        )
+        i, j = np.triu_indices(a.number_of_particles, 1)
+        types = a.particles["types"]
+        larger_pairs = (types[i] == 1) & (types[j] == 1)
+        self.assertGreater(distances[larger_pairs].min(), 0.8 * LJ_LARGER.sigma)
 
     def test_system_metropolis_configuration_has_no_overlap(self):
         # At 100 K a pair inside 0.8 sigma costs over 40 well depths and is

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -8,6 +8,8 @@ from pylj.potentials import LennardJones, SquareWell
 from pylj.tests.argon import (
     ARGON,
     ARGON_MODEL,
+    BUCKINGHAM_ARGON,
+    BUCKINGHAM_MODEL,
     LARGER,
     LJ_ARGON,
     MIXTURE_MODEL,
@@ -57,6 +59,16 @@ class TestUtil(unittest.TestCase):
                 a.pair_potentials, a.species[type_1], a.species[type_2]
             ).sigma
             self.assertGreaterEqual(a.distances[mask].min(), core)
+
+    def test_system_metropolis_places_buckingham_outside_its_turnover(self):
+        # The Buckingham form falls to minus infinity inside its barrier, so
+        # a trial there would be accepted as downhill and the run would
+        # collapse; the wall inside the turnover keeps every pair outside it.
+        a = util.System(
+            30, 300, 40, init_conf="metropolis", simulation="md", seed=0, **BUCKINGHAM_MODEL
+        )
+        self.assertGreater(a.distances.min(), BUCKINGHAM_ARGON.turnover)
+        self.assertTrue(np.isfinite(a.energies).all())
 
     def test_system_refuses_an_overlapping_lattice(self):
         # 16 argon on a 4 by 4 lattice in a 10 Angstrom box are 2.5 Angstrom
@@ -167,17 +179,17 @@ class TestUtil(unittest.TestCase):
                 util.System(2, 300, 8, simulation="md", placement_temperature=bad, **ARGON_MODEL)
 
     def test_system_metropolis_placement_temperature_governs_success(self):
-        # 50 argon particles in a 28 Angstrom box: as near-hard discs of
+        # 50 argon particles in a 27 Angstrom box: as near-hard discs of
         # diameter sigma (placement at 1 K) they exceed the packing that
         # sequential insertion reaches, but at 1000 K closer contacts are
         # tolerated and the configuration is still bound.
         with self.assertRaisesRegex(ValueError, "Could not place"):
             util.System(
-                50, 100, 28, init_conf="metropolis", simulation="md", seed=0,
+                50, 100, 27, init_conf="metropolis", simulation="md", seed=0,
                 placement_temperature=1.0, **ARGON_MODEL,
             )
         hot = util.System(
-            50, 100, 28, init_conf="metropolis", simulation="md", seed=0,
+            50, 100, 27, init_conf="metropolis", simulation="md", seed=0,
             placement_temperature=1000, **ARGON_MODEL,
         )
         assert_equal(hot.number_of_particles, 50)

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -3,9 +3,18 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from pylj import mc, md, util
+from pylj import mc, md, pairwise, util
 from pylj.potentials import LennardJones, SquareWell
-from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL, WELL, WELL_MODEL
+from pylj.tests.argon import (
+    ARGON,
+    ARGON_MODEL,
+    LARGER,
+    LJ_ARGON,
+    MIXTURE_MODEL,
+    WELL,
+    WELL_MIXTURE_MODEL,
+    WELL_MODEL,
+)
 
 
 class TestUtil(unittest.TestCase):
@@ -34,32 +43,39 @@ class TestUtil(unittest.TestCase):
         # A trial inside the square well's core costs infinite energy and is
         # always rejected, so no pair is closer than sigma.
         a = util.System(50, 300, 30, init_conf="metropolis", simulation="mc", seed=1, **WELL_MODEL)
-        a.compute_energy()
         self.assertGreaterEqual(a.distances.min(), WELL.sigma)
 
     def test_system_metropolis_places_a_mixture_with_each_pairs_own_potential(self):
         # Hard cores of three different diameters: no pair may sit inside the
-        # core of its own potential, exactly, at any seed. A placement using
-        # the wrong potential for a pair lets it inside the true core.
-        cores = {(ARGON, ARGON): 3e-10, (LARGER, LARGER): 5e-10, (ARGON, LARGER): 4e-10}
-        wells = {
-            pair: SquareWell(epsilon=1.5e-21, sigma=sigma, lambda_=1.5)
-            for pair, sigma in cores.items()
-        }
-        for seed in range(3):
-            a = util.System(
-                30, 300, 40, init_conf="metropolis", simulation="mc", seed=seed,
-                species=[ARGON, LARGER], pair_potentials=wells,
-            )
-            a.compute_energy()
-            i, j = np.triu_indices(a.number_of_particles, 1)
-            types = a.particles["types"]
-            for (one, other), sigma in cores.items():
-                index = (a.species.index(one), a.species.index(other))
-                mask = ((types[i] == index[0]) & (types[j] == index[1])) | (
-                    (types[i] == index[1]) & (types[j] == index[0])
-                )
-                self.assertGreaterEqual(a.distances[mask].min(), sigma)
+        # core of its own potential. A placement using the wrong potential
+        # for a pair lets it inside the true core.
+        a = util.System(
+            30, 300, 40, init_conf="metropolis", simulation="mc", seed=0, **WELL_MIXTURE_MODEL
+        )
+        for mask, type_1, type_2 in pairwise._species_pairs(a.particles["types"]):
+            core = pairwise.pair_potential(
+                a.pair_potentials, a.species[type_1], a.species[type_2]
+            ).sigma
+            self.assertGreaterEqual(a.distances[mask].min(), core)
+
+    def test_system_refuses_an_overlapping_lattice(self):
+        # 16 argon on a 4 by 4 lattice in a 10 Angstrom box are 2.5 Angstrom
+        # apart, inside sigma: about 90 k_B T of potential energy per particle.
+        with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
+            util.System(16, 300, 10, simulation="md", **ARGON_MODEL)
+
+    def test_system_refuses_a_lattice_inside_a_hard_core(self):
+        # 16 particles on a 4 by 4 lattice in a 10 Angstrom box are 2.5
+        # Angstrom apart, inside a 3 Angstrom hard core that the 5 Angstrom
+        # cut-off clears: the lattice energy is infinite.
+        with self.assertRaisesRegex(ValueError, "not finite"):
+            util.System(16, 300, 10, simulation="mc", **WELL_MODEL)
+
+    def test_system_accepts_a_lattice_below_the_energy_limit(self):
+        # 16 argon in a 12 Angstrom box store about 5.6 k_B T per particle
+        # at 300 K, under the limit of 10, and construct.
+        a = util.System(16, 300, 12, simulation="md", **ARGON_MODEL)
+        assert_equal(a.number_of_particles, 16)
 
     def test_system_refuses_a_potential_still_repulsive_at_the_cut_off(self):
         # Sigma given in Angstrom: the pair energy is astronomically positive
@@ -97,11 +113,10 @@ class TestUtil(unittest.TestCase):
                 simulation="md",
             )
 
-    def test_system_metropolis_configuration_has_no_overlap(self):
-        # At 100 K a pair inside 0.8 sigma costs over 40 well depths and is
-        # never accepted, so the closest pair sits outside the core.
+    def test_system_metropolis_places_a_soft_potential_outside_its_core(self):
+        # Lennard-Jones has no hard core, but at 100 K a pair inside 0.8
+        # sigma costs over 40 well depths and is never accepted.
         a = util.System(30, 100, 40, init_conf="metropolis", simulation="md", seed=0, **ARGON_MODEL)
-        a.compute_energy()
         self.assertGreater(a.distances.min(), 0.8 * LJ_ARGON.sigma)
 
     def test_system_metropolis_too_dense_raises(self):
@@ -152,36 +167,25 @@ class TestUtil(unittest.TestCase):
                 util.System(2, 300, 8, simulation="md", placement_temperature=bad, **ARGON_MODEL)
 
     def test_system_metropolis_placement_temperature_governs_success(self):
-        # 50 argon particles in a 25 Angstrom box: as near-hard discs of
+        # 50 argon particles in a 28 Angstrom box: as near-hard discs of
         # diameter sigma (placement at 1 K) they exceed the packing that
-        # sequential insertion reaches, but at 1e5 K overlaps are tolerated.
-        with self.assertRaises(ValueError):
+        # sequential insertion reaches, but at 1000 K closer contacts are
+        # tolerated and the configuration is still bound.
+        with self.assertRaisesRegex(ValueError, "Could not place"):
             util.System(
-                50, 100, 25, init_conf="metropolis", simulation="md", seed=0,
+                50, 100, 28, init_conf="metropolis", simulation="md", seed=0,
                 placement_temperature=1.0, **ARGON_MODEL,
             )
         hot = util.System(
-            50, 100, 25, init_conf="metropolis", simulation="md", seed=0,
-            placement_temperature=1e5, **ARGON_MODEL,
+            50, 100, 28, init_conf="metropolis", simulation="md", seed=0,
+            placement_temperature=1000, **ARGON_MODEL,
         )
         assert_equal(hot.number_of_particles, 50)
 
-    def test_system_too_big(self):
-        with self.assertRaises(AttributeError) as context:
-            util.System(2, 300, 1000, simulation="md", **ARGON_MODEL)
-        self.assertTrue(
-            "With a box length of 1000 the particles are probably "
-            "too small to be seen in the viewer. Try something "
-            "(much) less than 600." in str(context.exception)
-        )
-
-    def test_system_too_small(self):
-        with self.assertRaises(AttributeError) as context:
-            util.System(2, 300, 2, simulation="md", **ARGON_MODEL)
-        self.assertTrue(
-            "With a box length of 2 the cell is too small to "
-            "really hold more than one particle." in str(context.exception)
-        )
+    def test_system_refuses_a_box_outside_the_viewer_range(self):
+        for box_length in (2, 1000):
+            with self.assertRaisesRegex(ValueError, "between 4 and 600 Angstrom"):
+                util.System(2, 300, box_length, simulation="md", **ARGON_MODEL)
 
     def test_system_init_conf(self):
         with self.assertRaises(NotImplementedError) as context:

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -3,10 +3,10 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from pylj import mc, md, pairwise, util
+from pylj import mc, md, util
 from pylj.constants import BOLTZMANN
-from pylj.potentials import LennardJones, SquareWell
-from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL
+from pylj.potentials import LennardJones
+from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL, WELL, WELL_MODEL
 
 
 class TestUtil(unittest.TestCase):
@@ -30,21 +30,13 @@ class TestUtil(unittest.TestCase):
         assert_equal(a.number_of_particles, 2)
         for axis in ("xposition", "yposition"):
             self.assertTrue(np.all((0 <= a.particles[axis]) & (a.particles[axis] < a.box_length)))
-        assert_almost_equal(a.cut_off * 1e10, 4.0)
-        assert_equal(a.distances.size, 1)
 
     def test_system_metropolis_places_a_hard_core_outside_its_diameter(self):
         # A trial inside the square well's core costs infinite energy and is
         # always rejected, so no pair is closer than sigma.
-        well = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
-        a = util.System(
-            50, 300, 30, init_conf="metropolis", simulation="mc", seed=1,
-            species=[ARGON], pair_potentials={(ARGON, ARGON): well},
-        )
-        distances, _ = pairwise.compute_energy(
-            a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
-        )
-        self.assertGreaterEqual(distances.min(), well.sigma)
+        a = util.System(50, 300, 30, init_conf="metropolis", simulation="mc", seed=1, **WELL_MODEL)
+        a.compute_energy()
+        self.assertGreaterEqual(a.distances.min(), WELL.sigma)
 
     def test_system_metropolis_places_a_mixture_with_each_pairs_own_potential(self):
         # Under its own potential no placed pair can sit at a repulsive energy
@@ -56,10 +48,8 @@ class TestUtil(unittest.TestCase):
             a = util.System(
                 20, 100, 60, init_conf="metropolis", simulation="md", seed=seed, **MIXTURE_MODEL
             )
-            _, energies = pairwise.compute_energy(
-                a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
-            )
-            self.assertLess(energies.max(), 20 * BOLTZMANN * 100)
+            a.compute_energy()
+            self.assertLess(a.energies.max(), 20 * BOLTZMANN * 100)
 
     def test_system_refuses_a_potential_still_repulsive_at_the_cut_off(self):
         # Sigma given in Angstrom: the pair energy is astronomically positive
@@ -76,17 +66,16 @@ class TestUtil(unittest.TestCase):
         mistyped[(ARGON, LARGER)] = LennardJones(epsilon=1.577e-21, sigma=4.186)
         with self.assertRaisesRegex(ValueError, "between argon and larger"):
             util.System(
-                4, 100, 60, species=[ARGON, LARGER], pair_potentials=mistyped, simulation="md"
+                4, 100, 60, species=MIXTURE_MODEL["species"], pair_potentials=mistyped,
+                simulation="md",
             )
 
     def test_system_metropolis_configuration_has_no_overlap(self):
         # At 100 K a pair inside 0.8 sigma costs over 40 well depths and is
         # never accepted, so the closest pair sits outside the core.
         a = util.System(30, 100, 40, init_conf="metropolis", simulation="md", seed=0, **ARGON_MODEL)
-        distances, _ = pairwise.compute_energy(
-            a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
-        )
-        self.assertGreater(distances.min(), 0.8 * LJ_ARGON.sigma)
+        a.compute_energy()
+        self.assertGreater(a.distances.min(), 0.8 * LJ_ARGON.sigma)
 
     def test_system_metropolis_too_dense_raises(self):
         with self.assertRaisesRegex(ValueError, f"after {util.PLACEMENT_ATTEMPTS} attempts"):
@@ -122,7 +111,7 @@ class TestUtil(unittest.TestCase):
             np.random.set_state(state)
         assert_equal(first.particles["xposition"], second.particles["xposition"])
 
-    def test_system_metropolis_defaults_placement_temperature_to_the_run_temperature(self):
+    def test_system_defaults_placement_temperature_to_the_run_temperature(self):
         default = util.System(2, 300, 8, simulation="md", **ARGON_MODEL)
         explicit = util.System(
             2, 300, 8, simulation="md", placement_temperature=1000, **ARGON_MODEL

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -4,8 +4,9 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, md, pairwise, util
+from pylj.constants import BOLTZMANN
 from pylj.potentials import LennardJones, SquareWell
-from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, LJ_LARGER, MIXTURE_MODEL
+from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL
 
 
 class TestUtil(unittest.TestCase):
@@ -46,18 +47,29 @@ class TestUtil(unittest.TestCase):
         self.assertGreaterEqual(distances.min(), well.sigma)
 
     def test_system_metropolis_places_a_mixture_with_each_pairs_own_potential(self):
-        # The larger species has a 5 Angstrom core; its pairs must respect
-        # that, not argon's 3.4 Angstrom one.
-        a = util.System(
-            20, 100, 60, init_conf="metropolis", simulation="md", seed=2, **MIXTURE_MODEL
-        )
-        distances, _ = pairwise.compute_energy(
-            a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
-        )
-        i, j = np.triu_indices(a.number_of_particles, 1)
-        types = a.particles["types"]
-        larger_pairs = (types[i] == 1) & (types[j] == 1)
-        self.assertGreater(distances[larger_pairs].min(), 0.8 * LJ_LARGER.sigma)
+        # Under its own potential no placed pair can sit at a repulsive energy
+        # the acceptance could not have passed: a single pair above 20 k_B T
+        # cannot be offset by a few attractive neighbours. Evaluating every
+        # pair with its own potential catches a placement that used the
+        # wrong one, whatever the seed.
+        for seed in range(5):
+            a = util.System(
+                20, 100, 60, init_conf="metropolis", simulation="md", seed=seed, **MIXTURE_MODEL
+            )
+            _, energies = pairwise.compute_energy(
+                a.particles, a.box_length, a.cut_off, a.pair_potentials, a.species
+            )
+            self.assertLess(energies.max(), 20 * BOLTZMANN * 100)
+
+    def test_system_refuses_a_potential_still_repulsive_at_the_cut_off(self):
+        # Sigma given in Angstrom: the pair energy is astronomically positive
+        # at the cut-off, where a sensible potential has died away.
+        in_angstrom = LennardJones(epsilon=1.577e-21, sigma=3.372)
+        with self.assertRaisesRegex(ValueError, "at the cut-off"):
+            util.System(
+                2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom},
+                simulation="md",
+            )
 
     def test_system_metropolis_configuration_has_no_overlap(self):
         # At 100 K a pair inside 0.8 sigma costs over 40 well depths and is
@@ -69,7 +81,7 @@ class TestUtil(unittest.TestCase):
         self.assertGreater(distances.min(), 0.8 * LJ_ARGON.sigma)
 
     def test_system_metropolis_too_dense_raises(self):
-        with self.assertRaisesRegex(ValueError, "after 1000 attempts"):
+        with self.assertRaisesRegex(ValueError, f"after {util.PLACEMENT_ATTEMPTS} attempts"):
             util.System(200, 100, 20, init_conf="metropolis", simulation="md", **ARGON_MODEL)
 
     def test_system_metropolis_seed_reproduces_placement(self):

--- a/pylj/tests/test_util.py
+++ b/pylj/tests/test_util.py
@@ -4,8 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import mc, md, util
-from pylj.constants import BOLTZMANN
-from pylj.potentials import LennardJones
+from pylj.potentials import LennardJones, SquareWell
 from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL, WELL, WELL_MODEL
 
 
@@ -39,17 +38,28 @@ class TestUtil(unittest.TestCase):
         self.assertGreaterEqual(a.distances.min(), WELL.sigma)
 
     def test_system_metropolis_places_a_mixture_with_each_pairs_own_potential(self):
-        # Under its own potential no placed pair can sit at a repulsive energy
-        # the acceptance could not have passed: a single pair above 20 k_B T
-        # cannot be offset by a few attractive neighbours. Evaluating every
-        # pair with its own potential catches a placement that used the
-        # wrong one, whatever the seed.
-        for seed in range(5):
+        # Hard cores of three different diameters: no pair may sit inside the
+        # core of its own potential, exactly, at any seed. A placement using
+        # the wrong potential for a pair lets it inside the true core.
+        cores = {(ARGON, ARGON): 3e-10, (LARGER, LARGER): 5e-10, (ARGON, LARGER): 4e-10}
+        wells = {
+            pair: SquareWell(epsilon=1.5e-21, sigma=sigma, lambda_=1.5)
+            for pair, sigma in cores.items()
+        }
+        for seed in range(3):
             a = util.System(
-                20, 100, 60, init_conf="metropolis", simulation="md", seed=seed, **MIXTURE_MODEL
+                30, 300, 40, init_conf="metropolis", simulation="mc", seed=seed,
+                species=[ARGON, LARGER], pair_potentials=wells,
             )
             a.compute_energy()
-            self.assertLess(a.energies.max(), 20 * BOLTZMANN * 100)
+            i, j = np.triu_indices(a.number_of_particles, 1)
+            types = a.particles["types"]
+            for (one, other), sigma in cores.items():
+                index = (a.species.index(one), a.species.index(other))
+                mask = ((types[i] == index[0]) & (types[j] == index[1])) | (
+                    (types[i] == index[1]) & (types[j] == index[0])
+                )
+                self.assertGreaterEqual(a.distances[mask].min(), sigma)
 
     def test_system_refuses_a_potential_still_repulsive_at_the_cut_off(self):
         # Sigma given in Angstrom: the pair energy is astronomically positive
@@ -59,6 +69,23 @@ class TestUtil(unittest.TestCase):
             util.System(
                 2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom},
                 simulation="md",
+            )
+
+    def test_system_refuses_a_potential_still_attractive_at_the_cut_off(self):
+        # Epsilon typed in kJ/mol: a well about 1e17 k_B T deep at the cut-off.
+        deep = LennardJones(epsilon=0.95, sigma=3.372e-10)
+        with self.assertRaisesRegex(ValueError, "at the cut-off"):
+            util.System(
+                2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): deep},
+                simulation="md",
+            )
+
+    def test_system_refuses_a_hard_core_wider_than_the_cut_off(self):
+        wide = SquareWell(epsilon=1.5e-21, sigma=8e-10, lambda_=1.5)
+        with self.assertRaisesRegex(ValueError, "hard core is wider than the cut-off"):
+            util.System(
+                2, 300, 10, species=[ARGON], pair_potentials={(ARGON, ARGON): wide},
+                simulation="mc",
             )
 
     def test_system_refuses_a_cross_potential_still_repulsive_at_the_cut_off(self):

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -51,7 +51,7 @@ def _check_pair_potentials(species: Sequence[Species], pair_potentials: PairPote
 def _check_potentials_at_the_cut_off(
     species: Sequence[Species], pair_potentials: PairPotentials, cut_off: float, temperature: float
 ) -> None:
-    """Check that each species' own pair energy has died away at the cut-off.
+    """Check that every pair potential's energy has died away at the cut-off.
 
     Args:
         species: The species in the system.
@@ -60,20 +60,22 @@ def _check_potentials_at_the_cut_off(
         temperature: The temperature, in kelvin.
 
     Raises:
-        ValueError: If a species' pair energy with itself at the cut-off is
-            not finite or exceeds ``k_B T``, which is what a potential whose
+        ValueError: If any pair potential's energy at the cut-off is not
+            finite or exceeds ``k_B T``, which is what a potential whose
             parameters are in the wrong units looks like.
     """
-    for one in species:
-        potential = pairwise.pair_potential(pair_potentials, one, one)
+    for one, other in itertools.combinations_with_replacement(species, 2):
+        potential = pairwise.pair_potential(pair_potentials, one, other)
         at_cut_off = np.asarray(potential.energies(np.array([cut_off])), dtype=float).reshape(-1)
         energy = float(at_cut_off[0])
         if not np.isfinite(energy) or energy > BOLTZMANN * temperature:
+            pair = f"{one.name or 'particles'} and {other.name or 'particles'}"
             raise ValueError(
-                f"{type(potential).__name__} between two {one.name or 'particles'} is still "
+                f"{type(potential).__name__} between {pair} is still "
                 f"{energy / (BOLTZMANN * temperature):.3g} k_B T at the cut-off of "
                 f"{cut_off * 1e10:.1f} Angstrom, where the interaction should have died away. "
-                "Check that its parameters are in metres and joules, or use a larger cut-off."
+                "Check that its parameters are in metres and joules, or use a larger box or "
+                "cut-off."
             )
 
 
@@ -87,9 +89,11 @@ def check_initial_energy(system: "System", energy: float) -> None:
     than thermal energy.
 
     Potential energy stored in an initial configuration is released as
-    motion over the first steps, so by equipartition a configuration holding
-    ``x`` k_B T per particle heats to roughly ``x`` times its temperature.
-    Overlapping particles store enormous energy.
+    motion over the first steps. With the thermal energy already present, a
+    configuration holding ``x`` k_B T per particle can by equipartition
+    heat to as much as roughly ``x + 1`` times its temperature; how much of
+    the stored energy is released depends on where the configuration
+    relaxes to. Overlapping particles store enormous energy.
 
     Args:
         system: The system, after placement.
@@ -108,8 +112,8 @@ def check_initial_energy(system: "System", energy: float) -> None:
     if per_particle > INITIAL_ENERGY_LIMIT:
         raise ValueError(
             f"The initial configuration stores {per_particle:.3g} k_B T of potential energy per "
-            f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}; by equipartition, released "
-            f"as motion it would heat the system to roughly {per_particle:.3g} times "
+            f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}; released as motion it "
+            f"could raise the temperature to as much as roughly {per_particle + 1:.3g} times "
             f"{system.temperature:g} K. Particles overlap: use fewer particles, a larger box, or "
             "init_conf='metropolis'."
         )
@@ -197,10 +201,13 @@ class System:
     ValueError
         If the temperature or placement temperature is not positive and
         finite, ``species`` is empty, a pair of species has no potential or
-        one given in both orders, or a species' own pair energy at the
-        cut-off is not finite or exceeds k_B T.
+        one given in both orders, a pair potential's energy at the cut-off
+        is not finite or exceeds k_B T, or Metropolis placement exhausts its
+        trial budget or receives NaN from a potential.
     TypeError
         If a pair potential is not a ``PairPotential`` instance.
+    NotImplementedError
+        If ``init_conf`` is not ``'square'`` or ``'metropolis'``.
     """
 
     def __init__(

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -65,7 +65,7 @@ def _check_potentials_at_the_cut_off(
 
     Truncating the interaction at the cut-off assumes it is negligible
     there. The check is that each pair energy at the cut-off is finite and
-    within ``k_B T`` of zero, on either side.
+    within ``k_B T`` of zero.
 
     Args:
         species: The species in the system.
@@ -145,8 +145,9 @@ class System:
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     cut_off: float (optional)
-        The distance apart that the particles must be to consider their
-        interaction to be negligible.
+        The separation, in Angstrom, beyond which a pair's interaction is
+        taken as negligible. Ignored for a box of 30 Angstrom or under,
+        where half the box is used.
     placement_temperature: float (optional)
         Temperature, in kelvin, of the Metropolis acceptance used by
         ``init_conf='metropolis'``; by default the run temperature. The

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -55,33 +55,51 @@ def _check_pair_potentials(species: Sequence[Species], pair_potentials: PairPote
 
 
 def _check_potentials_at_the_cut_off(
-    species: Sequence[Species], pair_potentials: PairPotentials, cut_off: float, temperature: float
+    species: Sequence[Species],
+    pair_potentials: PairPotentials,
+    cut_off: float,
+    temperature: float,
+    cut_off_from_box: bool,
 ) -> None:
-    """Check that every pair potential's energy has died away at the cut-off.
+    """Check that every pair potential has died away at the cut-off.
+
+    Truncating the interaction at the cut-off assumes it is negligible
+    there. The check is that each pair energy at the cut-off is finite and
+    within ``k_B T`` of zero, on either side.
 
     Args:
         species: The species in the system.
         pair_potentials: The potential between each pair of species.
         cut_off: The cut-off, in metres.
         temperature: The temperature, in kelvin.
+        cut_off_from_box: Whether the cut-off is half the box, so a larger
+            box is the remedy.
 
     Raises:
         ValueError: If any pair potential's energy at the cut-off is not
-            finite or exceeds ``k_B T``, which is what a potential whose
-            parameters are in the wrong units looks like.
+            finite or larger in magnitude than ``k_B T``.
     """
+    where = f"the cut-off of {cut_off * 1e10:.1f} Angstrom"
+    if cut_off_from_box:
+        where += " (half the box)"
+    remedy = "Use a larger box" if cut_off_from_box else "Use a larger box or cut-off"
     for one, other in itertools.combinations_with_replacement(species, 2):
         potential = pairwise.pair_potential(pair_potentials, one, other)
         at_cut_off = np.asarray(potential.energies(np.array([cut_off])), dtype=float)
         energy = float(np.ravel(at_cut_off)[0])
-        if not np.isfinite(energy) or energy > BOLTZMANN * temperature:
-            pair = f"{one.name or 'particles'} and {other.name or 'particles'}"
+        pair = f"{type(potential).__name__} between {one.name or 'particles'} and " \
+               f"{other.name or 'particles'}"
+        if not np.isfinite(energy):
             raise ValueError(
-                f"{type(potential).__name__} between {pair} is still "
-                f"{energy / (BOLTZMANN * temperature):.3g} k_B T at the cut-off of "
-                f"{cut_off * 1e10:.1f} Angstrom, where the interaction should have died away. "
-                "Check that its parameters are in metres and joules, or use a larger box or "
-                "cut-off."
+                f"{pair} is infinite at {where}: its hard core is wider than the cut-off. "
+                f"{remedy}."
+            )
+        if abs(energy) > BOLTZMANN * temperature:
+            raise ValueError(
+                f"{pair} is still {energy / (BOLTZMANN * temperature):+.3g} k_B T at {where}; "
+                "the cut-off assumes the interaction has died away there. "
+                f"{remedy}, or a potential that has decayed by the cut-off; parameters given "
+                "in the wrong units (metres and joules are expected) are one cause."
             )
 
 
@@ -95,14 +113,9 @@ def check_initial_energy(system: "System") -> None:
     than thermal energy.
 
     Potential energy stored in an initial configuration is released as
-    motion over the first steps. With the thermal energy already present, a
-    configuration holding ``x`` k_B T per particle can by equipartition
-    heat to as much as roughly ``x + 1`` times its temperature; how much of
-    the stored energy is released depends on where the configuration
-    relaxes to. Overlapping particles store enormous energy.
-
-    The factories validate the configuration they derive; ``System`` itself
-    validates the model and places unconditionally.
+    motion over the first steps and heats the run. A configuration holding
+    more than :data:`INITIAL_ENERGY_LIMIT` k_B T per particle has particles
+    too close together for its temperature.
 
     Args:
         system: The system, after placement and a pair-energy evaluation.
@@ -111,7 +124,11 @@ def check_initial_energy(system: "System") -> None:
         ValueError: If the total pair energy is not finite, or exceeds
             :data:`INITIAL_ENERGY_LIMIT` k_B T per particle.
     """
-    remedy = "Use fewer particles, a larger box, or init_conf='metropolis'."
+    remedy = (
+        "Use fewer particles or a larger box; with init_conf='metropolis', a lower "
+        "placement_temperature keeps particles further apart, and from a lattice, "
+        "init_conf='metropolis' places them by energy."
+    )
     energy = float(system.energies.sum())
     if not np.isfinite(energy):
         raise ValueError(
@@ -121,9 +138,8 @@ def check_initial_energy(system: "System") -> None:
     if per_particle > INITIAL_ENERGY_LIMIT:
         raise ValueError(
             f"The initial configuration stores {per_particle:.3g} k_B T of potential energy per "
-            f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}; released as motion it "
-            f"could raise the temperature to as much as roughly {per_particle + 1:.3g} times "
-            f"{system.temperature:g} K. Particles overlap. {remedy}"
+            f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}: its particles are too close "
+            f"together for {system.temperature:g} K. {remedy}"
         )
 
 
@@ -205,12 +221,15 @@ class System:
         If the temperature or placement temperature is not positive and
         finite, ``species`` is empty, a pair of species has no potential or
         one given in both orders, a pair potential's energy at the cut-off
-        is not finite or exceeds k_B T, or Metropolis placement exhausts its
-        trial budget.
+        is not finite or larger in magnitude than k_B T, Metropolis
+        placement exhausts its trial budget, or ``simulation`` is not
+        ``'md'`` or ``'mc'``.
     TypeError
         If a pair potential is not a ``PairPotential`` instance.
     NotImplementedError
         If ``init_conf`` is not ``'square'`` or ``'metropolis'``.
+    AttributeError
+        If the box length is below 4 or above 600 Angstrom.
     """
 
     def __init__(
@@ -268,7 +287,8 @@ class System:
         else:
             self.cut_off = box_length / 2 * 1e-10
         _check_potentials_at_the_cut_off(
-            self.species, self.pair_potentials, self.cut_off, self.temperature
+            self.species, self.pair_potentials, self.cut_off, self.temperature,
+            cut_off_from_box=box_length <= 30,
         )
         if init_conf == "square":
             self.square()
@@ -393,9 +413,9 @@ class System:
         is attractive is always accepted.
 
         Sequential insertion is an initialiser, not an equilibrium sample:
-        the placed configuration is free of hard overlaps, close contacts
-        become likelier as the placement temperature rises, and the run
-        equilibrates it.
+        the placed configuration avoids the close contacts the potential
+        penalises at the placement temperature, closer contacts become
+        likelier as that temperature rises, and the run equilibrates it.
 
         Raises:
             ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -98,7 +98,7 @@ class System:
         lowering it packs more tightly and can exhaust the trial budget.
         Ignored by ``'square'``.
     seed: int (optional)
-        Seed for the random number generator used to place a random initial
+        Seed for the random number generator used to place an initial
         configuration, draw the initial velocities and make Monte Carlo
         moves. The same seed reproduces the same run. Without one the run
         differs each time.
@@ -290,8 +290,8 @@ class System:
 
         The lattice has ``ceil(sqrt(number_of_particles))`` sites along each
         side of the box and the particles fill it in order. No overlap check
-        is made: a lattice too dense for the potential gives a large initial
-        energy on the first evaluation.
+        is made: a lattice too dense for the potential gives a large, or for
+        a hard core infinite, initial energy on the first evaluation.
         """
         m = int(np.ceil(np.sqrt(self.number_of_particles)))
         d = self.box_length / m
@@ -308,15 +308,17 @@ class System:
 
         Each particle in turn is given a uniform trial position in the box,
         accepted by :func:`mc.accept` at ``placement_temperature`` on its
-        interaction energy with the particles already placed, and redrawn on
-        rejection. Inserting from vacuum makes that energy the energy change
-        of the insertion, so an overlapping trial is rejected with
-        probability close to one and an attractive one is always accepted.
+        total interaction energy with the particles already placed, and
+        redrawn on rejection. Inserting from vacuum makes that energy the
+        energy change of the insertion, so a trial that overlaps a core is
+        rejected with probability close to one and one whose net interaction
+        is attractive is always accepted.
         The first particle interacts with nothing and is always accepted.
 
         Sequential insertion is an initialiser, not an equilibrium sample:
-        the placed configuration is free of overlaps at the placement
-        temperature, and the run equilibrates it.
+        the placed configuration is free of hard overlaps, close contacts
+        become likelier as the placement temperature rises, and the run
+        equilibrates it.
 
         Raises:
             ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are
@@ -341,9 +343,9 @@ class System:
                     f"Could not place particle {i + 1} of {self.number_of_particles} in a "
                     f"{self.box_length * 1e10:.1f} Angstrom box at a placement temperature of "
                     f"{self.placement_temperature:g} K after {PLACEMENT_ATTEMPTS} attempts; "
-                    "reduce the number of particles, use a larger box, raise "
-                    "placement_temperature, or start from a square lattice "
-                    "(init_conf='square')."
+                    "reduce the number of particles or use a larger box; for a soft "
+                    "potential, raising placement_temperature tolerates closer contacts; "
+                    "and check the units of the potential's parameters (metres and joules)."
                 )
 
     def compute_force(self):

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -85,10 +85,11 @@ def _check_potentials_at_the_cut_off(
     remedy = "Use a larger box" if cut_off_from_box else "Use a larger box or cut-off"
     for one, other in itertools.combinations_with_replacement(species, 2):
         potential = pairwise.pair_potential(pair_potentials, one, other)
-        at_cut_off = np.asarray(potential.energies(np.array([cut_off])), dtype=float)
-        energy = float(np.ravel(at_cut_off)[0])
-        pair = f"{type(potential).__name__} between {one.name or 'particles'} and " \
-               f"{other.name or 'particles'}"
+        energy = float(potential.energies(np.array([cut_off]))[0])
+        pair = (
+            f"{type(potential).__name__} between {one.name or 'particles'} and "
+            f"{other.name or 'particles'}"
+        )
         if not np.isfinite(energy):
             raise ValueError(
                 f"{pair} is infinite at {where}: its hard core is wider than the cut-off. "
@@ -98,49 +99,13 @@ def _check_potentials_at_the_cut_off(
             raise ValueError(
                 f"{pair} is still {energy / (BOLTZMANN * temperature):+.3g} k_B T at {where}; "
                 "the cut-off assumes the interaction has died away there. "
-                f"{remedy}, or a potential that has decayed by the cut-off; parameters given "
-                "in the wrong units (metres and joules are expected) are one cause."
+                f"{remedy}, or check the parameter units: metres and joules are expected."
             )
 
 
 #: Largest potential energy per particle, in units of k_B T, accepted for an
-#: initial configuration by :func:`md.initialise` and :func:`mc.initialise`.
+#: initial configuration by :class:`System`.
 INITIAL_ENERGY_LIMIT = 10.0
-
-
-def check_initial_energy(system: "System") -> None:
-    """Refuse a starting configuration that stores far more potential energy
-    than thermal energy.
-
-    Potential energy stored in an initial configuration is released as
-    motion over the first steps and heats the run. A configuration holding
-    more than :data:`INITIAL_ENERGY_LIMIT` k_B T per particle has particles
-    too close together for its temperature.
-
-    Args:
-        system: The system, after placement and a pair-energy evaluation.
-
-    Raises:
-        ValueError: If the total pair energy is not finite, or exceeds
-            :data:`INITIAL_ENERGY_LIMIT` k_B T per particle.
-    """
-    remedy = (
-        "Use fewer particles or a larger box; with init_conf='metropolis', a lower "
-        "placement_temperature keeps particles further apart, and from a lattice, "
-        "init_conf='metropolis' places them by energy."
-    )
-    energy = float(system.energies.sum())
-    if not np.isfinite(energy):
-        raise ValueError(
-            f"The initial pair energy is not finite: particles sit inside a hard core. {remedy}"
-        )
-    per_particle = energy / (system.number_of_particles * BOLTZMANN * system.temperature)
-    if per_particle > INITIAL_ENERGY_LIMIT:
-        raise ValueError(
-            f"The initial configuration stores {per_particle:.3g} k_B T of potential energy per "
-            f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}: its particles are too close "
-            f"together for {system.temperature:g} K. {remedy}"
-        )
 
 
 class System:
@@ -207,6 +172,8 @@ class System:
         The temperature given at construction, in kelvin.
     placement_temperature: float
         The Metropolis placement temperature, in kelvin.
+    energies: numpy.ndarray
+        The pair energies of the current configuration, in joules.
     energy: float
         The total pair energy of the current configuration, in joules, for a
         Monte Carlo system: computed at construction, kept current by
@@ -221,15 +188,15 @@ class System:
         If the temperature or placement temperature is not positive and
         finite, ``species`` is empty, a pair of species has no potential or
         one given in both orders, a pair potential's energy at the cut-off
-        is not finite or larger in magnitude than k_B T, Metropolis
-        placement exhausts its trial budget, or ``simulation`` is not
-        ``'md'`` or ``'mc'``.
+        is not finite or larger in magnitude than k_B T, the box length is
+        outside 4 to 600 Angstrom, Metropolis placement exhausts its trial
+        budget, the initial configuration's pair energy is not finite or
+        exceeds :data:`INITIAL_ENERGY_LIMIT` k_B T per particle, or
+        ``simulation`` is not ``'md'`` or ``'mc'``.
     TypeError
         If a pair potential is not a ``PairPotential`` instance.
     NotImplementedError
         If ``init_conf`` is not ``'square'`` or ``'metropolis'``.
-    AttributeError
-        If the box length is below 4 or above 600 Angstrom.
     """
 
     def __init__(
@@ -261,34 +228,21 @@ class System:
         self.pair_potentials = dict(pair_potentials)
         _check_pair_potentials(self.species, self.pair_potentials)
         self.rng = np.random.default_rng(seed)
-        if box_length <= 600:
-            self.box_length = box_length * 1e-10
-        else:
-            raise AttributeError(
-                f"With a box length of {box_length} the particles are "
-                "probably too small to be seen in the "
-                "viewer. Try something (much) less than "
-                "600."
+        if not 4 <= box_length <= 600:
+            raise ValueError(
+                f"box_length must be between 4 and 600 Angstrom, not {box_length}: below 4 the "
+                "cell cannot hold more than one particle, and above 600 the particles are too "
+                "small to be seen in the viewer."
             )
-        if box_length >= 4:
-            self.box_length = box_length * 1e-10
-        else:
-            raise AttributeError(
-                f"With a box length of {box_length} the cell is too "
-                "small to really hold more than one "
-                "particle."
-            )
+        self.box_length = box_length * 1e-10
         self.timestep_length = timestep_length
         self.particles: np.ndarray = np.zeros(self.number_of_particles, dtype=particle_dt())
         self.particles["types"] = np.arange(self.number_of_particles) % len(self.species)
         self.masses = pairwise.particle_masses(self.particles, self.species)
-        if box_length > 30:
-            self.cut_off = cut_off * 1e-10
-        else:
-            self.cut_off = box_length / 2 * 1e-10
+        cut_off_from_box = box_length <= 30
+        self.cut_off = (box_length / 2 if cut_off_from_box else cut_off) * 1e-10
         _check_potentials_at_the_cut_off(
-            self.species, self.pair_potentials, self.cut_off, self.temperature,
-            cut_off_from_box=box_length <= 30,
+            self.species, self.pair_potentials, self.cut_off, self.temperature, cut_off_from_box
         )
         if init_conf == "square":
             self.square()
@@ -314,10 +268,40 @@ class System:
         self.energy_sample = np.array([])
         self.step_sample = np.array([])
         self.initial_particles = np.array(self.particles)
-        self.energy = 0.0
-        if simulation == "mc":
-            self.compute_energy()
-            self.energy = float(self.energies.sum())
+        self.compute_energy()
+        self._check_initial_energy()
+        self.energy = float(self.energies.sum()) if simulation == "mc" else 0.0
+
+    def _check_initial_energy(self) -> None:
+        """Refuse a starting configuration that stores far more potential
+        energy than thermal energy.
+
+        Potential energy stored in an initial configuration is released as
+        motion over the first steps and heats the run. A configuration
+        holding more than :data:`INITIAL_ENERGY_LIMIT` k_B T per particle
+        has particles too close together for its temperature.
+
+        Raises:
+            ValueError: If the total pair energy is not finite, or exceeds
+                :data:`INITIAL_ENERGY_LIMIT` k_B T per particle.
+        """
+        remedy = (
+            "Use fewer particles or a larger box; init_conf='metropolis' places particles by "
+            "energy, and a lower placement_temperature there keeps them further apart."
+        )
+        energy = float(self.energies.sum())
+        if not np.isfinite(energy):
+            raise ValueError(
+                f"The initial pair energy is not finite: particles sit inside a hard core. "
+                f"{remedy}"
+            )
+        per_particle = energy / (self.number_of_particles * BOLTZMANN * self.temperature)
+        if per_particle > INITIAL_ENERGY_LIMIT:
+            raise ValueError(
+                f"The initial configuration stores {per_particle:.3g} k_B T of potential energy "
+                f"per particle, above the limit of {INITIAL_ENERGY_LIMIT:g}: its particles are "
+                f"too close together for {self.temperature:g} K. {remedy}"
+            )
 
     def number_of_pairs(self):
         """Calculates the number of pairwise interactions in the simulation.
@@ -408,9 +392,7 @@ class System:
         accepted by :func:`mc.accept` at ``placement_temperature`` on its
         total interaction energy with the particles already placed, and
         redrawn on rejection. Inserting from vacuum makes that energy the
-        energy change of the insertion, so a trial that overlaps a core is
-        rejected with probability close to one and one whose net interaction
-        is attractive is always accepted.
+        energy change of the insertion.
 
         Sequential insertion is an initialiser, not an equilibrium sample:
         the placed configuration avoids the close contacts the potential
@@ -419,21 +401,18 @@ class System:
 
         Raises:
             ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are
-                rejected for a single particle.
+                rejected for a single particle. Near the density the budget
+                allows, whether that happens depends on the draw, so the
+                same call can place with one seed and raise with another.
         """
-        x = self.particles["xposition"]
-        y = self.particles["yposition"]
-        types = self.particles["types"]
         for i in range(self.number_of_particles):
+            species_index = int(self.particles["types"][i])
             placed = self.particles[:i]
             for _attempt in range(PLACEMENT_ATTEMPTS):
-                trial = (self.rng.uniform(0, self.box_length), self.rng.uniform(0, self.box_length))
-                energy = pairwise.particle_energy(
-                    trial, int(types[i]), placed,
-                    self.box_length, self.cut_off, self.pair_potentials, self.species,
-                )
+                trial = self._random_position()
+                energy = self._interaction_energy(trial, species_index, placed)
                 if mc.accept(energy, self.placement_temperature, rng=self.rng):
-                    x[i], y[i] = trial
+                    self.particles["xposition"][i], self.particles["yposition"][i] = trial
                     break
             else:
                 raise ValueError(
@@ -443,6 +422,20 @@ class System:
                     "reduce the number of particles or use a larger box; for a soft "
                     "potential, raising placement_temperature tolerates closer contacts."
                 )
+
+    def _random_position(self) -> tuple[float, float]:
+        """Draw a position uniformly over the box."""
+        return (self.rng.uniform(0, self.box_length), self.rng.uniform(0, self.box_length))
+
+    def _interaction_energy(
+        self, position: tuple[float, float], species_index: int, others: np.ndarray
+    ) -> float:
+        """The energy of a particle of one species at a position, with the
+        given particles, under this system's potentials and cut-off."""
+        return pairwise.particle_energy(
+            position, species_index, others,
+            self.box_length, self.cut_off, self.pair_potentials, self.species,
+        )
 
     def compute_force(self):
         """Compute the pair forces and the accelerations of the current
@@ -520,19 +513,13 @@ class System:
             The proposed configuration and its energy change.
         """
         particle = int(self.rng.integers(self.number_of_particles))
-        trial = (self.rng.uniform(0, self.box_length), self.rng.uniform(0, self.box_length))
+        trial = self._random_position()
         current = (self.particles["xposition"][particle], self.particles["yposition"][particle])
         species_index = int(self.particles["types"][particle])
         others = np.delete(self.particles, particle)
-        trial_energy = pairwise.particle_energy(
-            trial, species_index, others,
-            self.box_length, self.cut_off, self.pair_potentials, self.species,
-        )
-        current_energy = pairwise.particle_energy(
-            current, species_index, others,
-            self.box_length, self.cut_off, self.pair_potentials, self.species,
-        )
-        energy_change = trial_energy - current_energy
+        energy_change = self._interaction_energy(
+            trial, species_index, others
+        ) - self._interaction_energy(current, species_index, others)
         xposition = self.particles["xposition"].copy()
         yposition = self.particles["yposition"].copy()
         xposition[particle], yposition[particle] = trial

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -16,6 +16,12 @@ from pylj.potentials import PairPotential, Species
 PLACEMENT_ATTEMPTS = 1000
 
 
+def _check_positive_finite(name: str, value: float) -> None:
+    """Raise ``ValueError`` unless ``value`` is positive and finite."""
+    if not (np.isfinite(value) and value > 0):
+        raise ValueError(f"{name} must be positive and finite, not {value}")
+
+
 def _check_pair_potentials(species: Sequence[Species], pair_potentials: PairPotentials) -> None:
     """Check that a system's model is complete.
 
@@ -66,8 +72,8 @@ def _check_potentials_at_the_cut_off(
     """
     for one, other in itertools.combinations_with_replacement(species, 2):
         potential = pairwise.pair_potential(pair_potentials, one, other)
-        at_cut_off = np.asarray(potential.energies(np.array([cut_off])), dtype=float).reshape(-1)
-        energy = float(at_cut_off[0])
+        at_cut_off = np.asarray(potential.energies(np.array([cut_off])), dtype=float)
+        energy = float(np.ravel(at_cut_off)[0])
         if not np.isfinite(energy) or energy > BOLTZMANN * temperature:
             pair = f"{one.name or 'particles'} and {other.name or 'particles'}"
             raise ValueError(
@@ -84,7 +90,7 @@ def _check_potentials_at_the_cut_off(
 INITIAL_ENERGY_LIMIT = 10.0
 
 
-def check_initial_energy(system: "System", energy: float) -> None:
+def check_initial_energy(system: "System") -> None:
     """Refuse a starting configuration that stores far more potential energy
     than thermal energy.
 
@@ -95,18 +101,21 @@ def check_initial_energy(system: "System", energy: float) -> None:
     the stored energy is released depends on where the configuration
     relaxes to. Overlapping particles store enormous energy.
 
+    The factories validate the configuration they derive; ``System`` itself
+    validates the model and places unconditionally.
+
     Args:
-        system: The system, after placement.
-        energy: The total pair energy of the initial configuration, in joules.
+        system: The system, after placement and a pair-energy evaluation.
 
     Raises:
-        ValueError: If ``energy`` is not finite, or exceeds
+        ValueError: If the total pair energy is not finite, or exceeds
             :data:`INITIAL_ENERGY_LIMIT` k_B T per particle.
     """
+    remedy = "Use fewer particles, a larger box, or init_conf='metropolis'."
+    energy = float(system.energies.sum())
     if not np.isfinite(energy):
         raise ValueError(
-            "The initial pair energy is not finite: particles sit inside a hard core. Use "
-            "init_conf='metropolis', fewer particles or a larger box."
+            f"The initial pair energy is not finite: particles sit inside a hard core. {remedy}"
         )
     per_particle = energy / (system.number_of_particles * BOLTZMANN * system.temperature)
     if per_particle > INITIAL_ENERGY_LIMIT:
@@ -114,8 +123,7 @@ def check_initial_energy(system: "System", energy: float) -> None:
             f"The initial configuration stores {per_particle:.3g} k_B T of potential energy per "
             f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}; released as motion it "
             f"could raise the temperature to as much as roughly {per_particle + 1:.3g} times "
-            f"{system.temperature:g} K. Particles overlap: use fewer particles, a larger box, or "
-            "init_conf='metropolis'."
+            f"{system.temperature:g} K. Particles overlap. {remedy}"
         )
 
 
@@ -151,10 +159,8 @@ class System:
     init_conf: string (optional)
         The way that the particles are initially positioned. Should be one of:
         - 'square', a square lattice
-        - 'metropolis', sequential Metropolis insertion: each particle is
-          given a uniform trial position, accepted by the Metropolis rule at
-          ``placement_temperature`` on its interaction energy with the
-          particles already placed
+        - 'metropolis', sequential Metropolis insertion at
+          ``placement_temperature``
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     cut_off: float (optional)
@@ -162,13 +168,10 @@ class System:
         interaction to be negligible.
     placement_temperature: float (optional)
         Temperature, in kelvin, of the Metropolis acceptance used by
-        ``init_conf='metropolis'``; by default the run temperature. It is a
-        parameter of the placement: the placed configuration is a starting
-        point that the run equilibrates, and the acceptance temperature only
-        sets how strictly close contacts are rejected. Raising it tolerates
-        closer contacts; lowering it rejects them more strictly and can
-        exhaust the trial budget.
-        Ignored by ``'square'``.
+        ``init_conf='metropolis'``; by default the run temperature. The
+        placed configuration is a starting point that the run equilibrates;
+        raising this tolerates closer contacts, lowering it rejects them more
+        strictly and can exhaust the trial budget. Ignored by ``'square'``.
     seed: int (optional)
         Seed for the random number generator used to place an initial
         configuration, draw the initial velocities and make Monte Carlo
@@ -203,7 +206,7 @@ class System:
         finite, ``species`` is empty, a pair of species has no potential or
         one given in both orders, a pair potential's energy at the cut-off
         is not finite or exceeds k_B T, or Metropolis placement exhausts its
-        trial budget or receives NaN from a potential.
+        trial budget.
     TypeError
         If a pair potential is not a ``PairPotential`` instance.
     NotImplementedError
@@ -229,15 +232,11 @@ class System:
             raise ValueError(f"simulation must be 'md' or 'mc', not {simulation!r}")
         self.simulation = simulation
         self.number_of_particles = number_of_particles
-        if not (np.isfinite(temperature) and temperature > 0):
-            raise ValueError(f"temperature must be positive and finite, not {temperature}")
+        _check_positive_finite("temperature", temperature)
         self.temperature = temperature
         if placement_temperature is None:
             placement_temperature = temperature
-        elif not (np.isfinite(placement_temperature) and placement_temperature > 0):
-            raise ValueError(
-                f"placement_temperature must be positive and finite, not {placement_temperature}"
-            )
+        _check_positive_finite("placement_temperature", placement_temperature)
         self.placement_temperature = placement_temperature
         self.species = list(species)
         self.pair_potentials = dict(pair_potentials)
@@ -400,8 +399,7 @@ class System:
 
         Raises:
             ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are
-                rejected for a single particle, or the pair potential returns
-                NaN for a trial position.
+                rejected for a single particle.
         """
         x = self.particles["xposition"]
         y = self.particles["yposition"]
@@ -414,11 +412,6 @@ class System:
                     trial, int(types[i]), placed,
                     self.box_length, self.cut_off, self.pair_potentials, self.species,
                 )
-                if np.isnan(energy):
-                    raise ValueError(
-                        "The pair potential returned NaN for a trial position; check its "
-                        "energies for a division by zero or an invalid parameter."
-                    )
                 if mc.accept(energy, self.placement_temperature, rng=self.rng):
                     x[i], y[i] = trial
                     break
@@ -428,8 +421,7 @@ class System:
                     f"{self.box_length * 1e10:.1f} Angstrom box at a placement temperature of "
                     f"{self.placement_temperature:g} K after {PLACEMENT_ATTEMPTS} attempts; "
                     "reduce the number of particles or use a larger box; for a soft "
-                    "potential, raising placement_temperature tolerates closer contacts; "
-                    "and check the units of the potential's parameters (metres and joules)."
+                    "potential, raising placement_temperature tolerates closer contacts."
                 )
 
     def compute_force(self):

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -7,6 +7,7 @@ from typing import Literal, Self
 import numpy as np
 
 from pylj import mc, md, pairwise
+from pylj.constants import BOLTZMANN
 from pylj.pairwise import PairPotentials
 from pylj.potentials import PairPotential, Species
 
@@ -45,6 +46,73 @@ def _check_pair_potentials(species: Sequence[Species], pair_potentials: PairPote
                 f"pair_potentials[{pair}] must be a PairPotential instance, such as "
                 f"LennardJones(epsilon=..., sigma=...), not {potential!r}"
             )
+
+
+def _check_potentials_at_the_cut_off(
+    species: Sequence[Species], pair_potentials: PairPotentials, cut_off: float, temperature: float
+) -> None:
+    """Check that each species' own pair energy has died away at the cut-off.
+
+    Args:
+        species: The species in the system.
+        pair_potentials: The potential between each pair of species.
+        cut_off: The cut-off, in metres.
+        temperature: The temperature, in kelvin.
+
+    Raises:
+        ValueError: If a species' pair energy with itself at the cut-off is
+            not finite or exceeds ``k_B T``, which is what a potential whose
+            parameters are in the wrong units looks like.
+    """
+    for one in species:
+        potential = pairwise.pair_potential(pair_potentials, one, one)
+        at_cut_off = np.asarray(potential.energies(np.array([cut_off])), dtype=float).reshape(-1)
+        energy = float(at_cut_off[0])
+        if not np.isfinite(energy) or energy > BOLTZMANN * temperature:
+            raise ValueError(
+                f"{type(potential).__name__} between two {one.name or 'particles'} is still "
+                f"{energy / (BOLTZMANN * temperature):.3g} k_B T at the cut-off of "
+                f"{cut_off * 1e10:.1f} Angstrom, where the interaction should have died away. "
+                "Check that its parameters are in metres and joules, or use a larger cut-off."
+            )
+
+
+#: Largest potential energy per particle, in units of k_B T, accepted for an
+#: initial configuration by :func:`md.initialise` and :func:`mc.initialise`.
+INITIAL_ENERGY_LIMIT = 10.0
+
+
+def check_initial_energy(system: "System", energy: float) -> None:
+    """Refuse a starting configuration that stores far more potential energy
+    than thermal energy.
+
+    Potential energy stored in an initial configuration is released as
+    motion over the first steps, so by equipartition a configuration holding
+    ``x`` k_B T per particle heats to roughly ``x`` times its temperature.
+    Overlapping particles store enormous energy.
+
+    Args:
+        system: The system, after placement.
+        energy: The total pair energy of the initial configuration, in joules.
+
+    Raises:
+        ValueError: If ``energy`` is not finite, or exceeds
+            :data:`INITIAL_ENERGY_LIMIT` k_B T per particle.
+    """
+    if not np.isfinite(energy):
+        raise ValueError(
+            "The initial pair energy is not finite: particles sit inside a hard core. Use "
+            "init_conf='metropolis', fewer particles or a larger box."
+        )
+    per_particle = energy / (system.number_of_particles * BOLTZMANN * system.temperature)
+    if per_particle > INITIAL_ENERGY_LIMIT:
+        raise ValueError(
+            f"The initial configuration stores {per_particle:.3g} k_B T of potential energy per "
+            f"particle, above the limit of {INITIAL_ENERGY_LIMIT:g}; by equipartition, released "
+            f"as motion it would heat the system to roughly {per_particle:.3g} times "
+            f"{system.temperature:g} K. Particles overlap: use fewer particles, a larger box, or "
+            "init_conf='metropolis'."
+        )
 
 
 class System:
@@ -90,12 +158,12 @@ class System:
         interaction to be negligible.
     placement_temperature: float (optional)
         Temperature, in kelvin, of the Metropolis acceptance used by
-        ``init_conf='metropolis'``; by default the run temperature. It sets
-        how strongly overlapping trial positions are rejected and is a
-        parameter of the placement, not a thermodynamic temperature: the
-        placed configuration is a starting point, not an equilibrium sample,
-        and the run equilibrates it. Raising it tolerates more overlap;
-        lowering it packs more tightly and can exhaust the trial budget.
+        ``init_conf='metropolis'``; by default the run temperature. It is a
+        parameter of the placement: the placed configuration is a starting
+        point that the run equilibrates, and the acceptance temperature only
+        sets how strictly close contacts are rejected. Raising it tolerates
+        closer contacts; lowering it rejects them more strictly and can
+        exhaust the trial budget.
         Ignored by ``'square'``.
     seed: int (optional)
         Seed for the random number generator used to place an initial
@@ -128,8 +196,9 @@ class System:
     ------
     ValueError
         If the temperature or placement temperature is not positive and
-        finite, ``species`` is empty, or a pair of species has no potential
-        or one given in both orders.
+        finite, ``species`` is empty, a pair of species has no potential or
+        one given in both orders, or a species' own pair energy at the
+        cut-off is not finite or exceeds k_B T.
     TypeError
         If a pair potential is not a ``PairPotential`` instance.
     """
@@ -192,6 +261,9 @@ class System:
             self.cut_off = cut_off * 1e-10
         else:
             self.cut_off = box_length / 2 * 1e-10
+        _check_potentials_at_the_cut_off(
+            self.species, self.pair_potentials, self.cut_off, self.temperature
+        )
         if init_conf == "square":
             self.square()
         elif init_conf == "metropolis":
@@ -313,7 +385,6 @@ class System:
         energy change of the insertion, so a trial that overlaps a core is
         rejected with probability close to one and one whose net interaction
         is attractive is always accepted.
-        The first particle interacts with nothing and is always accepted.
 
         Sequential insertion is an initialiser, not an equilibrium sample:
         the placed configuration is free of hard overlaps, close contacts
@@ -322,7 +393,8 @@ class System:
 
         Raises:
             ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are
-                rejected for a single particle.
+                rejected for a single particle, or the pair potential returns
+                NaN for a trial position.
         """
         x = self.particles["xposition"]
         y = self.particles["yposition"]
@@ -335,6 +407,11 @@ class System:
                     trial, int(types[i]), placed,
                     self.box_length, self.cut_off, self.pair_potentials, self.species,
                 )
+                if np.isnan(energy):
+                    raise ValueError(
+                        "The pair potential returned NaN for a trial position; check its "
+                        "energies for a division by zero or an invalid parameter."
+                    )
                 if mc.accept(energy, self.placement_temperature, rng=self.rng):
                     x[i], y[i] = trial
                     break

--- a/pylj/util.py
+++ b/pylj/util.py
@@ -10,8 +10,8 @@ from pylj import mc, md, pairwise
 from pylj.pairwise import PairPotentials
 from pylj.potentials import PairPotential, Species
 
-#: Number of rejection-sampling attempts made for a single particle in
-#: :meth:`System.random` before it gives up and raises ``ValueError``.
+#: Number of trial positions tried for a single particle by Metropolis
+#: placement before it gives up and raises ``ValueError``.
 PLACEMENT_ATTEMPTS = 1000
 
 
@@ -78,15 +78,25 @@ class System:
         by :func:`md.initialise` and :func:`mc.initialise`.
     init_conf: string (optional)
         The way that the particles are initially positioned. Should be one of:
-        - 'square'
-        - 'random'
-        Both raise ``ValueError`` if the particles cannot be placed without
-        their repulsive cores overlapping.
+        - 'square', a square lattice
+        - 'metropolis', sequential Metropolis insertion: each particle is
+          given a uniform trial position, accepted by the Metropolis rule at
+          ``placement_temperature`` on its interaction energy with the
+          particles already placed
     timestep_length: float (optional)
         Length for each Velocity-Verlet integration step, in seconds.
     cut_off: float (optional)
         The distance apart that the particles must be to consider their
         interaction to be negligible.
+    placement_temperature: float (optional)
+        Temperature, in kelvin, of the Metropolis acceptance used by
+        ``init_conf='metropolis'``; by default the run temperature. It sets
+        how strongly overlapping trial positions are rejected and is a
+        parameter of the placement, not a thermodynamic temperature: the
+        placed configuration is a starting point, not an equilibrium sample,
+        and the run equilibrates it. Raising it tolerates more overlap;
+        lowering it packs more tightly and can exhaust the trial budget.
+        Ignored by ``'square'``.
     seed: int (optional)
         Seed for the random number generator used to place a random initial
         configuration, draw the initial velocities and make Monte Carlo
@@ -102,12 +112,10 @@ class System:
         The potential acting between each pair of species.
     masses: numpy.ndarray
         The mass of each particle, in atomic mass units, from its species.
-    cores: list of float
-        Separation at which each species' pair energy falls to zero, in
-        metres. Particles of one species are placed at least this far apart,
-        and particles of two species at least the mean of their cores apart.
     temperature: float
         The temperature given at construction, in kelvin.
+    placement_temperature: float
+        The Metropolis placement temperature, in kelvin.
     energy: float
         The total pair energy of the current configuration, in joules, for a
         Monte Carlo system: computed at construction, kept current by
@@ -119,8 +127,9 @@ class System:
     Raises
     ------
     ValueError
-        If the temperature is not positive and finite, ``species`` is empty,
-        or a pair of species has no potential or one given in both orders.
+        If the temperature or placement temperature is not positive and
+        finite, ``species`` is empty, or a pair of species has no potential
+        or one given in both orders.
     TypeError
         If a pair potential is not a ``PairPotential`` instance.
     """
@@ -137,6 +146,7 @@ class System:
         init_conf: str = "square",
         timestep_length: float = 1e-14,
         cut_off: float = 15,
+        placement_temperature: float | None = None,
         seed: int | None = None,
     ):
         if simulation not in ("md", "mc"):
@@ -146,11 +156,16 @@ class System:
         if not (np.isfinite(temperature) and temperature > 0):
             raise ValueError(f"temperature must be positive and finite, not {temperature}")
         self.temperature = temperature
+        if placement_temperature is None:
+            placement_temperature = temperature
+        elif not (np.isfinite(placement_temperature) and placement_temperature > 0):
+            raise ValueError(
+                f"placement_temperature must be positive and finite, not {placement_temperature}"
+            )
+        self.placement_temperature = placement_temperature
         self.species = list(species)
         self.pair_potentials = dict(pair_potentials)
         _check_pair_potentials(self.species, self.pair_potentials)
-        self.cores: list[float] = []
-        self.setup_cores()
         self.rng = np.random.default_rng(seed)
         if box_length <= 600:
             self.box_length = box_length * 1e-10
@@ -173,22 +188,22 @@ class System:
         self.particles: np.ndarray = np.zeros(self.number_of_particles, dtype=particle_dt())
         self.particles["types"] = np.arange(self.number_of_particles) % len(self.species)
         self.masses = pairwise.particle_masses(self.particles, self.species)
-        if init_conf == "square":
-            self.square()
-        elif init_conf == "random":
-            self.random()
-        else:
-            raise NotImplementedError(
-                f"The initial configuration type {init_conf} is "
-                "not recognised. Available options are: "
-                "square or random"
-            )
-        self.particles["xunwrapped"] = self.particles["xposition"]
-        self.particles["yunwrapped"] = self.particles["yposition"]
         if box_length > 30:
             self.cut_off = cut_off * 1e-10
         else:
             self.cut_off = box_length / 2 * 1e-10
+        if init_conf == "square":
+            self.square()
+        elif init_conf == "metropolis":
+            self._place_by_metropolis()
+        else:
+            raise NotImplementedError(
+                f"The initial configuration type {init_conf} is "
+                "not recognised. Available options are: "
+                "square or metropolis"
+            )
+        self.particles["xunwrapped"] = self.particles["xposition"]
+        self.particles["yunwrapped"] = self.particles["yposition"]
         self.step = 0
         self.time = 0.0
         self.distances = np.zeros(self.number_of_pairs())
@@ -232,7 +247,7 @@ class System:
             argon = Species(mass=39.948, name="argon")
             lj = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
             system = md.initialise(
-                100, 300, 40, "random",
+                100, 300, 40, "metropolis",
                 species=[argon], pair_potentials={(argon, argon): lj},
             )
             for _ in range(1000):
@@ -271,30 +286,15 @@ class System:
         return new
 
     def square(self) -> None:
-        """Places the particles on a square lattice.
+        """Place the particles on a square lattice.
 
-        Raises:
-            ValueError: If the lattice spacing, ``box_length`` divided by
-                ``ceil(sqrt(number_of_particles))``, is less than the
-                largest repulsive core (``self.cores``). Reduce the number
-                of particles or use a larger box.
+        The lattice has ``ceil(sqrt(number_of_particles))`` sites along each
+        side of the box and the particles fill it in order. No overlap check
+        is made: a lattice too dense for the potential gives a large initial
+        energy on the first evaluation.
         """
         m = int(np.ceil(np.sqrt(self.number_of_particles)))
         d = self.box_length / m
-        core = max(self.cores)
-        if d < core:
-            n_max = int(np.floor(self.box_length / core)) ** 2
-            l_min = np.ceil(np.sqrt(self.number_of_particles)) * core
-            l_min_angstrom = np.ceil(l_min * 1e10 * 10) / 10
-            fits = "1 particle fits" if n_max == 1 else f"{n_max} particles fit"
-            raise ValueError(
-                f"A square lattice of {self.number_of_particles} particles in a "
-                f"{self.box_length * 1e10:.1f} Angstrom box spaces them {d * 1e10:.2f} "
-                f"Angstrom apart, less than the largest repulsive core of "
-                f"{core * 1e10:.2f} Angstrom; at most {fits} in this "
-                f"box, or a box of at least {l_min_angstrom:.1f} Angstrom fits "
-                f"{self.number_of_particles}."
-            )
         n = 0
         for i in range(0, m):
             for j in range(0, m):
@@ -303,135 +303,48 @@ class System:
                     self.particles[n]["yposition"] = (j + 0.5) * d
                     n += 1
 
-    def random(self) -> None:
-        """Places the particles at random positions, without overlap.
+    def _place_by_metropolis(self) -> None:
+        """Place the particles one at a time by Metropolis insertion.
 
-        Particles are placed one at a time by rejection sampling: a
-        candidate position for a particle is accepted only if, for every
-        already placed particle, the minimum-image distance between them is
-        at least the two particles' repulsive core, ``self.cores``, one per
-        species. Two particles of different species are kept at least
-        the mean of their two cores apart.
+        Each particle in turn is given a uniform trial position in the box,
+        accepted by :func:`mc.accept` at ``placement_temperature`` on its
+        interaction energy with the particles already placed, and redrawn on
+        rejection. Inserting from vacuum makes that energy the energy change
+        of the insertion, so an overlapping trial is rejected with
+        probability close to one and an attractive one is always accepted.
+        The first particle interacts with nothing and is always accepted.
 
-        Rejection sampling reaches area fractions of roughly 0.4 to 0.5;
-        near that limit the same call may succeed or raise depending on
-        the random draw.
+        Sequential insertion is an initialiser, not an equilibrium sample:
+        the placed configuration is free of overlaps at the placement
+        temperature, and the run equilibrates it.
 
         Raises:
-            ValueError: If :data:`PLACEMENT_ATTEMPTS` candidate positions are
-                rejected for a single particle, which suggests the particles
-                are too large, or too many, for the box. Reduce the number
-                of particles or use a larger box.
+            ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are
+                rejected for a single particle.
         """
         x = self.particles["xposition"]
         y = self.particles["yposition"]
-        for i in range(self.number_of_particles):
-            x[i], y[i] = self._place_particle(i, x, y)
-
-    def _place_particle(
-        self, index: int, placed_x: np.ndarray, placed_y: np.ndarray
-    ) -> tuple[float, float]:
-        """Find a non-overlapping position for one particle by rejection sampling.
-
-        Args:
-            index: Index of the particle being placed into
-                ``self.particles["types"]``.
-            placed_x: x positions of the particles already placed, indexed
-                0 to ``index - 1``.
-            placed_y: y positions of the particles already placed, indexed
-                0 to ``index - 1``.
-
-        Returns:
-            An (x, y) position, in metres, at least the mean of the two
-            particles' repulsive cores from every already-placed particle.
-
-        Raises:
-            ValueError: If :data:`PLACEMENT_ATTEMPTS` candidate positions are
-                rejected.
-        """
-        box_length = self.box_length
         types = self.particles["types"]
-        type_i = int(types[index])
-        cores = np.asarray(self.cores)
-        thresholds = (cores[type_i] + cores[types[:index]]) / 2
-        for _attempt in range(PLACEMENT_ATTEMPTS):
-            x = self.rng.uniform(0, box_length)
-            y = self.rng.uniform(0, box_length)
-            dx = x - placed_x[:index]
-            dy = y - placed_y[:index]
-            # minimum-image convention: wrap the separation to the
-            # nearest periodic copy of each already-placed particle
-            dx -= box_length * np.round(dx / box_length)
-            dy -= box_length * np.round(dy / box_length)
-            separations = np.sqrt(dx**2 + dy**2)
-            if np.all(separations >= thresholds):
-                return x, y
-        core_angstrom = self.cores[type_i] * 1e10
-        box_angstrom = box_length * 1e10
-        largest_core_angstrom = max(self.cores) * 1e10
-        area_fraction = (
-            sum(np.pi * (self.cores[int(t)] / 2) ** 2 for t in self.particles["types"])
-            / box_length**2
-        )
-        raise ValueError(
-            f"Could not place particle {index + 1} of {self.number_of_particles} "
-            f"(repulsive core {core_angstrom:.2f} Angstrom, largest "
-            f"{largest_core_angstrom:.2f} Angstrom) without overlap in a "
-            f"{box_angstrom:.1f} Angstrom box after {PLACEMENT_ATTEMPTS} attempts "
-            f"(requested area fraction {area_fraction:.2f}); reduce the number of particles or "
-            "use a larger box; a square lattice (init_conf='square') packs more "
-            "densely than random placement and may still fit."
-        )
-
-    def setup_cores(self) -> None:
-        """Set the separation at which each species' pair energy falls to
-        zero, in metres, one per species. Particles closer than this sit
-        inside each other's repulsive core, so the initial configurations
-        keep them at least this far apart.
-
-        Raises:
-            ValueError: If a potential's ``energies`` does not return one
-                value per separation, if its pair energy is positive at
-                every grid point between 0.1 and 50 Angstrom (suggesting its
-                parameters are in the wrong units), or if its pair energy
-                never falls from positive to non-positive on that range, so
-                it has no repulsive core there.
-        """
-        r = np.logspace(-11, np.log10(5e-9), 4000)
-        self.cores = []
-        for one in self.species:
-            potential = pairwise.pair_potential(self.pair_potentials, one, one)
-            name = type(potential).__name__
-            energy = np.asarray(potential.energies(r), dtype=float)
-            if energy.shape != r.shape:
-                raise ValueError(
-                    f"{name}.energies must return one value per separation; got "
-                    f"shape {energy.shape} for {r.shape[0]} separations"
+        for i in range(self.number_of_particles):
+            placed = self.particles[:i]
+            for _attempt in range(PLACEMENT_ATTEMPTS):
+                trial = (self.rng.uniform(0, self.box_length), self.rng.uniform(0, self.box_length))
+                energy = pairwise.particle_energy(
+                    trial, int(types[i]), placed,
+                    self.box_length, self.cut_off, self.pair_potentials, self.species,
                 )
-            positive = energy > 0
-            crossings = np.flatnonzero(positive[:-1] & ~positive[1:])
-            if crossings.size == 0:
-                if positive.all():
-                    raise ValueError(
-                        f"{name}: the pair energy is still positive at 50 Angstrom; "
-                        "check the units of the parameters"
-                    )
-                raise ValueError(
-                    f"{name} has no repulsive core: its pair energy never falls from "
-                    "positive to zero between 0.1 and 50 Angstrom"
-                )
-            i = int(crossings[-1])
-            r0, r1 = r[i], r[i + 1]
-            e0, e1 = energy[i], energy[i + 1]
-            if np.isfinite(e0) and np.isfinite(e1):
-                # linear interpolation to the point where the energy is zero
-                core = r0 + (r1 - r0) * (-e0) / (e1 - e0)
+                if mc.accept(energy, self.placement_temperature, rng=self.rng):
+                    x[i], y[i] = trial
+                    break
             else:
-                # a discontinuous step (e.g. an infinite repulsive wall): the
-                # first non-positive grid point is a safe, slightly
-                # conservative estimate
-                core = r1
-            self.cores.append(float(core))
+                raise ValueError(
+                    f"Could not place particle {i + 1} of {self.number_of_particles} in a "
+                    f"{self.box_length * 1e10:.1f} Angstrom box at a placement temperature of "
+                    f"{self.placement_temperature:g} K after {PLACEMENT_ATTEMPTS} attempts; "
+                    "reduce the number of particles, use a larger box, raise "
+                    "placement_temperature, or start from a square lattice "
+                    "(init_conf='square')."
+                )
 
     def compute_force(self):
         """Compute the pair forces and the accelerations of the current


### PR DESCRIPTION
Initial configurations are placed by energy. The geometric `random` placement and the per-species repulsive "cores" it depended on are replaced by Metropolis insertion, and the `square` lattice places unconditionally. Part of the 2.0 work tracked in #86; the last of the slice 1 potential-model work, and the reversal of the `cores` machinery from #93.

## Placement

`init_conf` takes `'square'` or `'metropolis'`.

`'metropolis'` seats particles one at a time. Each particle is given a uniform trial position in the box and the trial is accepted by `mc.accept` on its total interaction energy with the particles already placed, computed with `pairwise.particle_energy`; a rejected trial is redrawn, up to `PLACEMENT_ATTEMPTS` per particle, after which `ValueError` names the box, the placement temperature and the remedies. Inserting from vacuum makes that energy the energy change of the insertion. It works for any potential, including a hard core: a square-well system places with no pair inside sigma, and a mixture places each pair on its own potential.

The acceptance temperature is a separate `placement_temperature` on `md.initialise`, `mc.initialise` and `System`, defaulting to the run temperature. Sequential insertion is an initialiser, not a canonical sample (earlier particles are never reweighted once later ones constrain them, and fixing the particle number means no chemical potential enters), so the temperature is a parameter of the placement rather than a thermodynamic one: raising it tolerates closer contacts, lowering it rejects them more strictly and can exhaust the trial budget. The docstrings say so, and that the run equilibrates the configuration.

`'square'` places on the lattice with no overlap check.

## Contract checks at the boundaries

With the geometric guards gone, the checks test the assumptions the model makes rather than diagnosing the input.

`System` checks the cut-off contract: for every unordered species pair the potential must be finite and within k_B T at the cut-off, since the engine treats the interaction as having died away there. A hard core wider than the cut-off, a potential still repulsive at the cut-off (parameters in Angstrom rather than metres, say) and one still attractive there (an epsilon in kJ/mol, say) are all refused. The message names the pair, the energy in units of k_B T, and the remedies; when the cut-off came from the box it says so and asks for a larger box.

`System` then checks the configuration the potential is asked to evaluate: a non-finite initial pair energy (particles inside a hard core) is refused, and so is a configuration storing more than `INITIAL_ENERGY_LIMIT` (10) k_B T of potential energy per particle, which is the over-dense lattice. The message names the stored energy, the temperature and the remedies, including a lower `placement_temperature`.

A box length outside 4 to 600 Angstrom raises `ValueError` rather than `AttributeError`.

## Potentials at short range

Placement by energy evaluates the potentials at separations a lattice never reaches. `LennardJones` is infinite at zero separation, where the difference form was NaN. `Buckingham` finds the top of its short-range barrier at construction, exposed as `turnover`, and is infinite in energy and force inside it: the form itself falls to minus infinity there, so a trial landing inside was accepted as downhill and the run collapsed.

## Notebooks

The Monte Carlo introduction moves onto `propose`, `accept` and `apply`, with the Metropolis condition written with its minus sign. The molecular dynamics introduction's exercise on starting configurations no longer presents Metropolis insertion as the high-energy start.

## Removed

`System.setup_cores`, `System.cores`, `System.random`, `System._place_particle`, the `square` lattice's core-based "fits" check and its message, the `'random'` option, and the units and energy-shape checks that lived in `setup_cores`. `cut_off` is computed before placement.
