### PR TITLE
Model type for species and pair potentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to pylj are recorded here. The format follows
 
 ## Unreleased
 
+### Added
+
+- `pylj.model.Model`, the species and the potential between each pair of them, validated when it is built; `Model.single(species, potential)` builds the one-species case, and `Model.potential(one, other)` looks a pair up in either order.
+
+### Changed
+
+- `MDSimulation.initialise` and `MCSimulation.initialise` take a `Model` as their one positional argument in place of the `species` and `pair_potentials` keywords, and the constructors take it in place of `pair_potentials`. A simulation holds it as `model`. `Configuration.pairs`, `potential_energy`, `forces`, `virial` and `insertion_energy`, `md.velocity_verlet`, `placement.place` and `placement.place_metropolis` take it likewise.
+
+### Removed
+
+- `pairwise.pair_potential` and the `PairPotentials` alias, replaced by `Model.potential`.
+
 ## 2.0.0b1 - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ All notable changes to pylj are recorded here. The format follows
 
 ### Added
 
-- `pylj.model.Model`, the species and the potential between each pair of them, validated when it is built; `Model.single(species, potential)` builds the one-species case, and `Model.potential(one, other)` looks a pair up in either order.
+- `pylj.model.Model`, the species and the potential between each pair of them, validated when it is built and read-only after; `Model.single(species, potential)` builds the one-species case, and `Model.potential(one, other)` looks a pair up in either order.
 
 ### Changed
 
-- `MDSimulation.initialise` and `MCSimulation.initialise` take a `Model` as their one positional argument in place of the `species` and `pair_potentials` keywords, and the constructors take it in place of `pair_potentials`. A simulation holds it as `model`. `Configuration.pairs`, `potential_energy`, `forces`, `virial` and `insertion_energy`, `md.velocity_verlet`, `placement.place` and `placement.place_metropolis` take it likewise.
+- `MDSimulation.initialise` and `MCSimulation.initialise` take a `Model` as their one positional argument in place of the `species` and `pair_potentials` keywords, and the constructors take it in place of `pair_potentials`. A simulation holds it as `model`. `Configuration.pairs`, `potential_energy`, `forces`, `virial` and `insertion_energy`, `md.velocity_verlet`, `placement.place` and `placement.place_metropolis` take it likewise; `place_metropolis` no longer takes `species` separately, since the model carries them.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to pylj are recorded here. The format follows
 ### Added
 
 - `pylj.model.Model`, the species and the potential between each pair of them, validated when it is built and read-only after; `Model.single(species, potential)` builds the one-species case, and `Model.potential(one, other)` looks a pair up in either order.
+- `LennardJones`, `Buckingham` and `SquareWell` print as the constructor call that built them, so a model shows its parameters in a notebook.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,13 @@ Twenty-five argon atoms at 300 K, run with molecular dynamics and drawn as they 
 ```python
 from pylj import sample
 from pylj.md import MDSimulation
+from pylj.model import Model
 from pylj.potentials import LennardJones, Species
 
 argon = Species(mass=39.948, name="argon")
 lj = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
-simulation = MDSimulation.initialise(
-    number_of_atoms=25,
-    temperature=300,
-    box=40,
-    species=[argon],
-    pair_potentials={(argon, argon): lj},
-    seed=1,
-)
+model = Model.single(argon, lj)
+simulation = MDSimulation.initialise(model, number_of_atoms=25, temperature=300, box=40, seed=1)
 viewer = sample.Interactions(simulation)
 for _ in range(2000):
     simulation.step()
@@ -59,14 +54,7 @@ The same model runs under Monte Carlo:
 ```python
 from pylj.mc import MCSimulation
 
-simulation = MCSimulation.initialise(
-    number_of_atoms=25,
-    temperature=300,
-    box=40,
-    species=[argon],
-    pair_potentials={(argon, argon): lj},
-    seed=1,
-)
+simulation = MCSimulation.initialise(model, number_of_atoms=25, temperature=300, box=40, seed=1)
 viewer = sample.Energy(simulation)
 for _ in range(5000):
     simulation.step()

--- a/docs/source/custom-potentials.md
+++ b/docs/source/custom-potentials.md
@@ -44,18 +44,13 @@ A purely repulsive potential has no energy minimum for a viewer to size the atom
 ```{code-cell} python
 from pylj import sample
 from pylj.md import MDSimulation
+from pylj.model import Model
 from pylj.potentials import Species
 
 argon = Species(mass=39.948, name="argon")
 soft = SoftSphere(epsilon=1.577e-21, sigma=3.372e-10)
-simulation = MDSimulation.initialise(
-    number_of_atoms=25,
-    temperature=300,
-    box=30,
-    species=[argon],
-    pair_potentials={(argon, argon): soft},
-    seed=0,
-)
+model = Model.single(argon, soft)
+simulation = MDSimulation.initialise(model, number_of_atoms=25, temperature=300, box=30, seed=0)
 viewer = sample.JustCell(simulation, diameter=3.4)
 for _ in range(300):
     simulation.step()
@@ -65,7 +60,7 @@ for _ in range(300):
 
 ## Mixtures
 
-A mixture is more species and one `pair_potentials` entry for each species with itself and for each pair of different species, in either order:
+A mixture is a `Model` with more species and one entry for each species with itself and for each pair of different species, in either order:
 
 ```python
 from pylj.potentials import LennardJones
@@ -74,14 +69,11 @@ xenon = Species(mass=131.293, name="xenon")
 lj_argon = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
 lj_xenon = LennardJones(epsilon=3.05e-21, sigma=3.98e-10)
 lj_cross = LennardJones(epsilon=2.19e-21, sigma=3.68e-10)
-mixture = MDSimulation.initialise(
-    number_of_atoms=24,
-    temperature=200,
-    box=40,
-    species=[argon, xenon],
-    pair_potentials={(argon, argon): lj_argon, (xenon, xenon): lj_xenon, (argon, xenon): lj_cross},
-    seed=0,
+mixture = Model(
+    (argon, xenon),
+    {(argon, argon): lj_argon, (xenon, xenon): lj_xenon, (argon, xenon): lj_cross},
 )
+simulation = MDSimulation.initialise(mixture, number_of_atoms=24, temperature=200, box=40, seed=0)
 ```
 
-Atoms are assigned to the species in turn. A missing pair raises `ValueError`; a potential class in place of an instance raises `TypeError`. The viewers draw each species at the minimum of its own pair potential unless `diameter` is given, as one value or one per species.
+Atoms are assigned to the species in turn. A missing pair raises `ValueError` and a potential class in place of an instance raises `TypeError`, both when the `Model` is built. The viewers draw each species at the minimum of its own pair potential unless `diameter` is given, as one value or one per species.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -17,14 +17,15 @@ plt.rcParams["figure.dpi"] = 100
 ## A model
 
 ```{code-cell} python
+from pylj.model import Model
 from pylj.potentials import LennardJones, Species
 
 argon = Species(mass=39.948, name="argon")
 lj = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
-model = dict(species=[argon], pair_potentials={(argon, argon): lj})
+model = Model.single(argon, lj)
 ```
 
-`Species` takes the mass in atomic mass units. `LennardJones` takes the well depth in joules and the zero-crossing separation in metres. `pair_potentials` maps each pair of species to the potential acting between them.
+`Species` takes the mass in atomic mass units. `LennardJones` takes the well depth in joules and the zero-crossing separation in metres. A `Model` is the species and the potential between each pair of them; `Model.single` builds it for one species.
 
 ## Molecular dynamics
 
@@ -32,7 +33,7 @@ model = dict(species=[argon], pair_potentials={(argon, argon): lj})
 from pylj import sample
 from pylj.md import MDSimulation
 
-simulation = MDSimulation.initialise(number_of_atoms=16, temperature=300, box=30, seed=1, **model)
+simulation = MDSimulation.initialise(model, number_of_atoms=16, temperature=300, box=30, seed=1)
 viewer = sample.Interactions(simulation)
 for _ in range(2000):
     simulation.step()
@@ -42,14 +43,14 @@ for _ in range(2000):
         viewer.update(simulation)
 ```
 
-`initialise` takes the number of atoms, the temperature in kelvin and the box side in Angstrom. `step()` advances one timestep, `heat_bath()` holds the temperature, `sample()` records the temperature, pressure and energies in `simulation.samples`, and the viewer redraws when asked.
+`initialise` takes the model, the number of atoms, the temperature in kelvin and the box side in Angstrom. `step()` advances one timestep, `heat_bath()` holds the temperature, `sample()` records the temperature, pressure and energies in `simulation.samples`, and the viewer redraws when asked.
 
 ## Monte Carlo
 
 ```{code-cell} python
 from pylj.mc import MCSimulation
 
-simulation = MCSimulation.initialise(number_of_atoms=16, temperature=300, box=20, seed=1, **model)
+simulation = MCSimulation.initialise(model, number_of_atoms=16, temperature=300, box=20, seed=1)
 viewer = sample.Energy(simulation)
 for _ in range(5000):
     simulation.step()

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -1,0 +1,8 @@
+pylj.model
+==========
+
+The physical model a simulation runs: the species and the potential between each pair of them.
+
+.. automodule:: pylj.model
+    :members:
+    :show-inheritance:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,8 +1,8 @@
 Modules
 =======
 
-Students import from ``pylj.md``, ``pylj.mc``, ``pylj.potentials`` and ``pylj.sample``.
-The other modules are the plumbing those four are built on.
+Students import from ``pylj.md``, ``pylj.mc``, ``pylj.model``, ``pylj.potentials`` and ``pylj.sample``.
+The other modules are the plumbing those five are built on.
 
 .. toctree::
    :maxdepth: 4
@@ -11,6 +11,7 @@ The other modules are the plumbing those four are built on.
    constants
    mc
    md
+   model
    pairwise
    placement
    potentials

--- a/docs/source/simulations.md
+++ b/docs/source/simulations.md
@@ -1,16 +1,15 @@
 # Simulations
 
-`MDSimulation` and `MCSimulation` share a base class, `Simulation`, and are built the same way. Both hold `configuration`, `pair_potentials`, `cut_off`, `rng`, `steps` and `samples`, and both have `step()`, `sample()` and `restart()`.
+`MDSimulation` and `MCSimulation` share a base class, `Simulation`, and are built the same way. Both hold `configuration`, `model`, `cut_off`, `rng`, `steps` and `samples`, and both have `step()`, `sample()` and `restart()`.
 
 ## Building a simulation
 
 ```python
 simulation = MDSimulation.initialise(
+    model,
     number_of_atoms=16,
     temperature=300,
     box=30,
-    species=[argon],
-    pair_potentials={(argon, argon): lj},
     init_conf="square",
     placement_temperature=None,
     timestep=1e-14,
@@ -19,15 +18,15 @@ simulation = MDSimulation.initialise(
 )
 ```
 
-Every argument is given by keyword. Five are required: `number_of_atoms`; `temperature`, in kelvin; `box`, the side of the square periodic box in Angstrom; `species`, a sequence of `Species`; and `pair_potentials`, a mapping from each pair of species to the potential between them. `init_conf` selects the starting positions: `"square"` places the atoms on a square lattice, and `"metropolis"` inserts them one at a time by Metropolis acceptance at `placement_temperature`, which defaults to `temperature`. `timestep` is in seconds and applies to molecular dynamics only. `cut_off` is in Angstrom and defaults to 15 or half the box, whichever is smaller; it may not exceed half the box. `seed` seeds `simulation.rng`, which draws the initial velocities and the Monte Carlo moves.
+`model`, a `Model` of the species and the potential between each pair of them, is the one positional argument; the rest are given by keyword. Three are required: `number_of_atoms`; `temperature`, in kelvin; and `box`, the side of the square periodic box in Angstrom. `init_conf` selects the starting positions: `"square"` places the atoms on a square lattice, and `"metropolis"` inserts them one at a time by Metropolis acceptance at `placement_temperature`, which defaults to `temperature`. `timestep` is in seconds and applies to molecular dynamics only. `cut_off` is in Angstrom and defaults to 15 or half the box, whichever is smaller; it may not exceed half the box. `seed` seeds `simulation.rng`, which draws the initial velocities and the Monte Carlo moves.
 
 A configuration whose pair energy is not finite or exceeds ten $k_B T$ per atom is refused with `ValueError`, as is a potential whose energy at the cut-off is larger than $k_B T$.
 
-The constructors take a ready configuration instead: `MDSimulation(configuration, pair_potentials, cut_off=None, timestep=1e-14, seed=None)` with an `MDConfiguration`, and `MCSimulation(configuration, pair_potentials, temperature, cut_off=None, seed=None)` with a `Configuration`, all in SI units.
+The constructors take a ready configuration instead: `MDSimulation(configuration, model, cut_off=None, timestep=1e-14, seed=None)` with an `MDConfiguration`, and `MCSimulation(configuration, model, temperature, cut_off=None, seed=None)` with a `Configuration`, all in SI units.
 
 ## The configuration
 
-`simulation.configuration` is the current state. `position` is an `(N, 2)` array in metres, `box` the side in metres, `species` and `species_index` name each atom's species, and `masses` is in kilograms. `pairs(pair_potentials, cut_off, forces=False)` evaluates every pair and returns their distances, separations, energies and, if asked, radial forces; `potential_energy`, `forces` and `virial` take the same arguments. An `MDConfiguration` adds `velocity` and `unwrapped`, the positions without periodic wrapping, and `kinetic_energy()`, `temperature()`, which divides the kinetic energy by $(N - 1) k_B$ because the centre of mass is held at rest, and `msd(initial)`.
+`simulation.configuration` is the current state. `position` is an `(N, 2)` array in metres, `box` the side in metres, `species` and `species_index` name each atom's species, and `masses` is in kilograms. `pairs(model, cut_off, forces=False)` evaluates every pair and returns their distances, separations, energies and, if asked, radial forces; `potential_energy`, `forces` and `virial` take the same arguments. An `MDConfiguration` adds `velocity` and `unwrapped`, the positions without periodic wrapping, and `kinetic_energy()`, `temperature()`, which divides the kinetic energy by $(N - 1) k_B$ because the centre of mass is held at rest, and `msd(initial)`.
 
 A configuration is never changed in place. `replace(**changes)` returns a copy with some arrays changed.
 

--- a/docs/source/viewers.md
+++ b/docs/source/viewers.md
@@ -37,19 +37,14 @@ Panes that plot a quantity against time read it from `simulation.samples`, so th
 
 ```{code-cell} python
 from pylj.md import MDSimulation
+from pylj.model import Model
 from pylj.potentials import LennardJones, Species
 from pylj.sample import CellPane, TemperaturePane, Viewer
 
 argon = Species(mass=39.948, name="argon")
 lj = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
-simulation = MDSimulation.initialise(
-    number_of_atoms=16,
-    temperature=300,
-    box=30,
-    species=[argon],
-    pair_potentials={(argon, argon): lj},
-    seed=0,
-)
+model = Model.single(argon, lj)
+simulation = MDSimulation.initialise(model, number_of_atoms=16, temperature=300, box=30, seed=0)
 viewer = Viewer(simulation, [CellPane(), TemperaturePane()])
 for _ in range(300):
     simulation.step()
@@ -89,14 +84,7 @@ class FirstAtomPane(Pane):
         ax.autoscale_view()
 
 
-simulation = MDSimulation.initialise(
-    number_of_atoms=16,
-    temperature=300,
-    box=30,
-    species=[argon],
-    pair_potentials={(argon, argon): lj},
-    seed=0,
-)
+simulation = MDSimulation.initialise(model, number_of_atoms=16, temperature=300, box=30, seed=0)
 viewer = Viewer(simulation, [CellPane(), FirstAtomPane()])
 for _ in range(300):
     simulation.step()

--- a/pylj/configuration.py
+++ b/pylj/configuration.py
@@ -56,8 +56,7 @@ class Configuration:
     description of how the atoms interact. Each method that evaluates the
     interactions between atoms is given a ``Model`` and a ``cut_off`` when it
     is called, so the same configuration can be evaluated under different
-    potentials.
-    Everything is in SI units.
+    potentials. Everything is in SI units.
 
     Attributes:
         position: The position of each atom, shape ``(N, 2)``, in

--- a/pylj/configuration.py
+++ b/pylj/configuration.py
@@ -53,9 +53,10 @@ class Configuration:
     """Where the atoms are: the state a Monte Carlo simulation evolves.
 
     A configuration cannot be changed once it is made, and it holds no
-    description of how the atoms interact. Each method that needs the
-    interaction is given a ``Model`` and ``cut_off`` when it is called, so the
-    same configuration can be evaluated under different potentials.
+    description of how the atoms interact. Each method that evaluates the
+    interactions between atoms is given a ``Model`` and a ``cut_off`` when it
+    is called, so the same configuration can be evaluated under different
+    potentials.
     Everything is in SI units.
 
     Attributes:
@@ -129,7 +130,7 @@ class Configuration:
         return dataclasses.replace(self, **arrays)
 
     def pairs(self, model: Model, cut_off: float, *, forces: bool = False) -> PairData:
-        """Evaluate every pair of atoms under the interaction law.
+        """Evaluate every pair of atoms under the model.
 
         Each pair is separated by its minimum-image distance, and the potential
         for the two species it joins gives its energy. A pair further apart

--- a/pylj/configuration.py
+++ b/pylj/configuration.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from pylj import pairwise
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
-from pylj.pairwise import PairPotentials
+from pylj.model import Model
 from pylj.potentials import Species
 
 
@@ -54,9 +54,9 @@ class Configuration:
 
     A configuration cannot be changed once it is made, and it holds no
     description of how the atoms interact. Each method that needs the
-    interaction law is given ``pair_potentials`` and ``cut_off`` when it is
-    called, so the same configuration can be evaluated under different
-    potentials. Everything is in SI units.
+    interaction is given a ``Model`` and ``cut_off`` when it is called, so the
+    same configuration can be evaluated under different potentials.
+    Everything is in SI units.
 
     Attributes:
         position: The position of each atom, shape ``(N, 2)``, in
@@ -128,9 +128,7 @@ class Configuration:
         }
         return dataclasses.replace(self, **arrays)
 
-    def pairs(
-        self, pair_potentials: PairPotentials, cut_off: float, *, forces: bool = False
-    ) -> PairData:
+    def pairs(self, model: Model, cut_off: float, *, forces: bool = False) -> PairData:
         """Evaluate every pair of atoms under the interaction law.
 
         Each pair is separated by its minimum-image distance, and the potential
@@ -144,7 +142,7 @@ class Configuration:
         still be used here.
 
         Args:
-            pair_potentials: The potential between each pair of species.
+            model: The species and the potential between each pair of them.
             cut_off: The separation beyond which a pair contributes nothing,
                 in metres.
             forces: Whether to evaluate the radial forces as well.
@@ -161,9 +159,7 @@ class Configuration:
         energy = np.zeros(distance.size)
         force = np.zeros(distance.size) if forces else None
         for mask, type_1, type_2 in pairwise.species_pairs(self.species_index):
-            potential = pairwise.pair_potential(
-                pair_potentials, self.species[type_1], self.species[type_2]
-            )
+            potential = model.potential(self.species[type_1], self.species[type_2])
             energy[mask] = potential.energies(distance[mask])
             forbidden = mask & (distance < potential.min_separation)
             if forbidden.any():
@@ -184,13 +180,13 @@ class Configuration:
             force[beyond] = 0.0
         return PairData(distance, separation, energy, force)
 
-    def potential_energy(self, pair_potentials: PairPotentials, cut_off: float) -> float:
+    def potential_energy(self, model: Model, cut_off: float) -> float:
         """The total pair energy, in joules."""
-        return float(self.pairs(pair_potentials, cut_off).energy.sum())
+        return float(self.pairs(model, cut_off).energy.sum())
 
-    def forces(self, pair_potentials: PairPotentials, cut_off: float) -> NDArray[np.float64]:
+    def forces(self, model: Model, cut_off: float) -> NDArray[np.float64]:
         """The net force on each atom, shape ``(N, 2)``, in newtons."""
-        pairs = self.pairs(pair_potentials, cut_off, forces=True)
+        pairs = self.pairs(model, cut_off, forces=True)
         radial = _radial_force(pairs)
         i, j = np.triu_indices(self.number_of_atoms, 1)
         # Each pair's radial force acts along its separation, pushing
@@ -201,15 +197,15 @@ class Configuration:
         np.add.at(force, j, -pair_force)
         return force
 
-    def virial(self, pair_potentials: PairPotentials, cut_off: float) -> float:
+    def virial(self, model: Model, cut_off: float) -> float:
         """The sum over pairs of the radial force times the distance, in joules."""
-        return self.pairs(pair_potentials, cut_off, forces=True).virial
+        return self.pairs(model, cut_off, forces=True).virial
 
     def insertion_energy(
         self,
         position: ArrayLike,
         species_index: int,
-        pair_potentials: PairPotentials,
+        model: Model,
         cut_off: float,
     ) -> float:
         """Return the interaction energy of one added atom with the atoms already
@@ -218,7 +214,7 @@ class Configuration:
         Args:
             position: The ``(x, y)`` position of the added atom, in metres.
             species_index: The index in ``species`` of its species.
-            pair_potentials: The potential between each pair of species.
+            model: The species and the potential between each pair of them.
             cut_off: The separation beyond which a pair contributes nothing,
                 in metres.
 
@@ -233,9 +229,7 @@ class Configuration:
         energy = np.zeros(distance.size)
         for other in np.unique(self.species_index):
             mask = self.species_index == other
-            potential = pairwise.pair_potential(
-                pair_potentials, self.species[species_index], self.species[int(other)]
-            )
+            potential = model.potential(self.species[species_index], self.species[int(other)])
             energy[mask] = potential.energies(distance[mask])
             energy[mask & (distance < potential.min_separation)] = np.inf
         energy[distance > cut_off] = 0.0

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -2,7 +2,6 @@
 criterion, the criterion itself, and the proposed move the criterion accepts or
 rejects."""
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Self
 
@@ -11,9 +10,9 @@ from numpy.typing import NDArray
 
 from pylj.configuration import Configuration
 from pylj.constants import BOLTZMANN
-from pylj.pairwise import PairPotentials
+from pylj.model import Model
 from pylj.placement import place
-from pylj.potentials import Species, check_positive_finite
+from pylj.potentials import check_positive_finite
 from pylj.simulation import (
     Samples,
     Simulation,
@@ -99,9 +98,9 @@ class MCSimulation(Simulation):
     Args:
         configuration: The starting configuration. An ``MDConfiguration``
             is accepted; its velocities are ignored.
-        pair_potentials: The potential between each pair of species. Only
-            the pair energies are evaluated, so a potential with no finite
-            force, such as the square well, can be used.
+        model: The species and the potential between each pair of them.
+            Only the pair energies are evaluated, so a potential with no
+            finite force, such as the square well, can be used.
         temperature: The temperature of the simulation, in kelvin.
         cut_off: The cut-off, in metres; see :class:`Simulation`.
         seed: Seed for the random number generator.
@@ -128,23 +127,17 @@ class MCSimulation(Simulation):
     def __init__(
         self,
         configuration: Configuration,
-        pair_potentials: PairPotentials,
+        model: Model,
         temperature: float,
         *,
         cut_off: float | None = None,
         seed: int | None = None,
     ) -> None:
         check_positive_finite("temperature", temperature)
-        super().__init__(configuration, pair_potentials, cut_off=cut_off, seed=seed)
+        super().__init__(configuration, model, cut_off=cut_off, seed=seed)
         self.temperature = temperature
-        _check_potentials_at_the_cut_off(
-            configuration.species,
-            self.pair_potentials,
-            self.cut_off,
-            temperature,
-            configuration.box,
-        )
-        self.energy = configuration.potential_energy(self.pair_potentials, self.cut_off)
+        _check_potentials_at_the_cut_off(self.model, self.cut_off, temperature, configuration.box)
+        self.energy = configuration.potential_energy(self.model, self.cut_off)
         _check_initial_energy(self.energy, configuration.number_of_atoms, temperature)
         self.accepted = 0
         self.samples = MCSamples()
@@ -152,12 +145,11 @@ class MCSimulation(Simulation):
     @classmethod
     def initialise(
         cls,
+        model: Model,
         *,
         number_of_atoms: int,
         temperature: float,
         box: float,
-        species: Sequence[Species],
-        pair_potentials: PairPotentials,
         init_conf: str = "square",
         placement_temperature: float | None = None,
         cut_off: float | None = None,
@@ -167,11 +159,11 @@ class MCSimulation(Simulation):
         temperature.
 
         Args:
+            model: The species, assigned to the atoms in turn, and the
+                potential between each pair of them.
             number_of_atoms: The number of atoms.
             temperature: The temperature of the simulation, in kelvin.
             box: The side length of the box, in Angstrom, from 4 to 600.
-            species: The species; atoms are assigned to them in turn.
-            pair_potentials: The potential between each pair of species.
             init_conf: ``'square'`` for a lattice or ``'metropolis'`` for
                 sequential Metropolis insertion.
             placement_temperature: The temperature of the Metropolis
@@ -196,14 +188,13 @@ class MCSimulation(Simulation):
             number_of_atoms,
             temperature,
             box,
-            species=species,
-            pair_potentials=pair_potentials,
+            model=model,
             init_conf=init_conf,
             placement_temperature=placement_temperature,
             cut_off=cut_off,
             rng=rng,
         )
-        simulation = cls(configuration, pair_potentials, temperature, cut_off=cut_off_metres)
+        simulation = cls(configuration, model, temperature, cut_off=cut_off_metres)
         simulation.rng = rng
         return simulation
 
@@ -225,8 +216,8 @@ class MCSimulation(Simulation):
         species_index = int(configuration.species_index[atom])
         others = configuration.without(atom)
         energy_change = others.insertion_energy(
-            trial, species_index, self.pair_potentials, self.cut_off
-        ) - others.insertion_energy(current, species_index, self.pair_potentials, self.cut_off)
+            trial, species_index, self.model, self.cut_off
+        ) - others.insertion_energy(current, species_index, self.model, self.cut_off)
         position = configuration.position.copy()
         position[atom] = trial
         return Proposal(position, energy_change, configuration)
@@ -272,7 +263,7 @@ class MCSimulation(Simulation):
         recorded value is exact; between samples ``apply`` keeps a running
         total.
         """
-        self.energy = self.configuration.potential_energy(self.pair_potentials, self.cut_off)
+        self.energy = self.configuration.potential_energy(self.model, self.cut_off)
         self.samples.add(step=self.steps, potential_energy=self.energy)
 
     def restart(self) -> Self:

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -2,7 +2,6 @@
 motion, the Velocity-Verlet integrator, and the velocity-rescaling
 thermostat."""
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Self
 
@@ -12,9 +11,9 @@ from numpy.typing import NDArray
 from pylj import pairwise
 from pylj.configuration import MDConfiguration
 from pylj.constants import BOLTZMANN
-from pylj.pairwise import PairPotentials
+from pylj.model import Model
 from pylj.placement import place
-from pylj.potentials import Species, check_positive_finite
+from pylj.potentials import check_positive_finite
 from pylj.simulation import (
     Samples,
     Simulation,
@@ -59,7 +58,7 @@ class MDSimulation(Simulation):
 
     Args:
         configuration: The starting configuration, with velocities.
-        pair_potentials: The potential between each pair of species.
+        model: The species and the potential between each pair of them.
         cut_off: The cut-off, in metres; see :class:`Simulation`.
         timestep: The length of each integration step, in seconds.
         seed: Seed for the random number generator.
@@ -90,7 +89,7 @@ class MDSimulation(Simulation):
     def __init__(
         self,
         configuration: MDConfiguration,
-        pair_potentials: PairPotentials,
+        model: Model,
         *,
         cut_off: float | None = None,
         timestep: float = 1e-14,
@@ -101,7 +100,7 @@ class MDSimulation(Simulation):
                 "MDSimulation needs an MDConfiguration, which carries velocities; build one "
                 "with MDSimulation.initialise(...) or construct an MDConfiguration."
             )
-        super().__init__(configuration, pair_potentials, cut_off=cut_off, seed=seed)
+        super().__init__(configuration, model, cut_off=cut_off, seed=seed)
         check_positive_finite("timestep", timestep)
         self.timestep = timestep
         temperature = configuration.temperature()
@@ -115,31 +114,24 @@ class MDSimulation(Simulation):
                 f"The configuration's temperature is {temperature}: the simulation it came "
                 "from has diverged."
             )
-        _check_potentials_at_the_cut_off(
-            configuration.species,
-            self.pair_potentials,
-            self.cut_off,
-            temperature,
-            configuration.box,
-        )
+        _check_potentials_at_the_cut_off(self.model, self.cut_off, temperature, configuration.box)
         _check_initial_energy(
-            configuration.potential_energy(self.pair_potentials, self.cut_off),
+            configuration.potential_energy(self.model, self.cut_off),
             configuration.number_of_atoms,
             temperature,
         )
-        self.forces = configuration.forces(self.pair_potentials, self.cut_off)
+        self.forces = configuration.forces(self.model, self.cut_off)
         self.initial_configuration = configuration
         self.samples = MDSamples()
 
     @classmethod
     def initialise(
         cls,
+        model: Model,
         *,
         number_of_atoms: int,
         temperature: float,
         box: float,
-        species: Sequence[Species],
-        pair_potentials: PairPotentials,
         init_conf: str = "square",
         placement_temperature: float | None = None,
         timestep: float = 1e-14,
@@ -159,11 +151,11 @@ class MDSimulation(Simulation):
         stored: molecular dynamics measures it.
 
         Args:
+            model: The species, assigned to the atoms in turn, and the
+                potential between each pair of them.
             number_of_atoms: The number of atoms, at least two.
             temperature: The initial temperature, in kelvin.
             box: The side length of the box, in Angstrom, from 4 to 600.
-            species: The species; atoms are assigned to them in turn.
-            pair_potentials: The potential between each pair of species.
             init_conf: ``'square'`` for a lattice or ``'metropolis'`` for
                 sequential Metropolis insertion.
             placement_temperature: The temperature of the Metropolis
@@ -195,8 +187,7 @@ class MDSimulation(Simulation):
             number_of_atoms,
             temperature,
             box,
-            species=species,
-            pair_potentials=pair_potentials,
+            model=model,
             init_conf=init_conf,
             placement_temperature=placement_temperature,
             cut_off=cut_off,
@@ -217,7 +208,7 @@ class MDSimulation(Simulation):
             ),
             temperature,
         )
-        simulation = cls(configuration, pair_potentials, cut_off=cut_off_metres, timestep=timestep)
+        simulation = cls(configuration, model, cut_off=cut_off_metres, timestep=timestep)
         simulation.rng = rng
         return simulation
 
@@ -233,7 +224,7 @@ class MDSimulation(Simulation):
         A subclass with a different integrator overrides this method.
         """
         self.configuration, self.forces = velocity_verlet(
-            self.configuration, self.forces, self.timestep, self.pair_potentials, self.cut_off
+            self.configuration, self.forces, self.timestep, self.model, self.cut_off
         )
 
     def step(self) -> None:
@@ -265,7 +256,7 @@ class MDSimulation(Simulation):
         """
         configuration = self.configuration
         kinetic_energy = configuration.kinetic_energy()
-        pairs = configuration.pairs(self.pair_potentials, self.cut_off, forces=True)
+        pairs = configuration.pairs(self.model, self.cut_off, forces=True)
         self.samples.add(
             step=self.steps,
             temperature=configuration.temperature(),
@@ -292,7 +283,7 @@ def velocity_verlet(
     configuration: MDConfiguration,
     forces: NDArray[np.float64],
     timestep: float,
-    pair_potentials: PairPotentials,
+    model: Model,
     cut_off: float,
 ) -> tuple[MDConfiguration, NDArray[np.float64]]:
     """Move a configuration one timestep forward with the Velocity-Verlet
@@ -307,7 +298,7 @@ def velocity_verlet(
         forces: The net force on each atom at that configuration, shape
             ``(N, 2)``, in newtons.
         timestep: The length of the step, in seconds.
-        pair_potentials: The potential between each pair of species.
+        model: The species and the potential between each pair of them.
         cut_off: The cut-off, in metres.
 
     Returns:
@@ -330,7 +321,7 @@ def velocity_verlet(
             "the timestep is too long, or the simulation has diverged."
         )
     moved = configuration.replace(position=position, unwrapped=unwrapped)
-    next_forces = moved.forces(pair_potentials, cut_off)
+    next_forces = moved.forces(model, cut_off)
     next_accelerations = next_forces / masses
     velocity = update_velocities(
         configuration.velocity, accelerations, next_accelerations, timestep

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -70,8 +70,9 @@ class Model:
             species, a pair of species has no potential, or a cross pair is
             given in both orders.
         TypeError: If ``species`` is a single ``Species`` rather than a
-            sequence, or a value in ``pair_potentials`` is not a
-            ``PairPotential`` instance.
+            sequence, an item of ``species`` is not a ``Species``, or a
+            value in ``pair_potentials`` is not a ``PairPotential``
+            instance.
     """
 
     def __init__(self, species: Sequence[Species], pair_potentials: PairPotentials) -> None:
@@ -81,6 +82,12 @@ class Model:
                 "for one species, Model.single(species, potential) builds the model"
             )
         self._species = tuple(species)
+        for one in self._species:
+            if not isinstance(one, Species):
+                raise TypeError(
+                    f"species must be Species instances, such as Species(mass=39.948, "
+                    f"name='argon'), not {one!r}"
+                )
         self._pair_potentials = MappingProxyType(dict(pair_potentials))
         _check_complete(self._species, self._pair_potentials)
 

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -16,7 +16,8 @@ def _check_complete(species: tuple[Species, ...], pair_potentials: PairPotential
     exactly one potential, and that no other pair has one.
 
     Raises:
-        ValueError: If ``species`` is empty or repeats a species, an entry of
+        ValueError: If ``species`` is empty or repeats a species, a key of
+            ``pair_potentials`` is not a pair, an entry of
             ``pair_potentials`` names something that is not one of the
             species, a pair of species has no entry in either order, or a
             cross pair has one in both orders.
@@ -28,6 +29,11 @@ def _check_complete(species: tuple[Species, ...], pair_potentials: PairPotential
     if len(set(species)) != len(species):
         raise ValueError("species must not repeat: two Species that compare equal are one species")
     for pair in pair_potentials:
+        if not isinstance(pair, tuple) or len(pair) != 2:
+            raise ValueError(
+                f"pair_potentials keys must be a pair of species, such as (argon, argon), "
+                f"not {pair!r}"
+            )
         for one in pair:
             if one not in species:
                 raise ValueError(
@@ -56,8 +62,8 @@ class Model:
 
     Every pair of species, including each species with itself, has one
     entry in ``pair_potentials``, keyed by the two species in either order.
-    ``single`` builds the model for one species. A model does not change
-    after it is built: ``species`` and ``pair_potentials`` are read-only.
+    ``single`` builds the model for one species. ``species`` and
+    ``pair_potentials`` are read-only.
 
     Args:
         species: The species, as any sequence of ``Species``. Atoms are
@@ -65,20 +71,21 @@ class Model:
         pair_potentials: The potential between each pair of species.
 
     Raises:
-        ValueError: If ``species`` is empty or repeats a species, an entry
-            of ``pair_potentials`` names something that is not one of the
+        ValueError: If ``species`` is empty or repeats a species, a key of
+            ``pair_potentials`` is not a pair, an entry of
+            ``pair_potentials`` names something that is not one of the
             species, a pair of species has no potential, or a cross pair is
             given in both orders.
         TypeError: If ``species`` is a single ``Species`` rather than a
-            sequence, an item of ``species`` is not a ``Species``, or a
-            value in ``pair_potentials`` is not a ``PairPotential``
-            instance.
+            sequence, an item of ``species`` is not a ``Species``,
+            ``pair_potentials`` is not a mapping, or a value in
+            ``pair_potentials`` is not a ``PairPotential`` instance.
     """
 
     def __init__(self, species: Sequence[Species], pair_potentials: PairPotentials) -> None:
-        if isinstance(species, Species):
+        if isinstance(species, Species | str):
             raise TypeError(
-                f"species must be a sequence of Species, such as ({species.name or 'argon'},); "
+                f"species must be a sequence of Species, such as ({species!r},); "
                 "for one species, Model.single(species, potential) builds the model"
             )
         self._species = tuple(species)
@@ -88,6 +95,12 @@ class Model:
                     f"species must be Species instances, such as Species(mass=39.948, "
                     f"name='argon'), not {one!r}"
                 )
+        if not isinstance(pair_potentials, Mapping):
+            raise TypeError(
+                f"pair_potentials must map each pair of species to its potential, such as "
+                f"{{(argon, argon): potential}}, not {pair_potentials!r}; for one species, "
+                "Model.single(species, potential) builds the model"
+            )
         self._pair_potentials = MappingProxyType(dict(pair_potentials))
         _check_complete(self._species, self._pair_potentials)
 
@@ -118,6 +131,10 @@ class Model:
         """Return the potential between two species.
 
         The pair may be given in either order.
+
+        Args:
+            one: One species of the pair.
+            other: The other species; the same one for a pair of like atoms.
 
         Raises:
             KeyError: If either species is not in the model.

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -8,10 +8,10 @@ from typing import Self
 
 from pylj.potentials import PairPotential, Species
 
-PairPotentials = Mapping[tuple[Species, Species], PairPotential]
 
-
-def _check_complete(species: tuple[Species, ...], pair_potentials: PairPotentials) -> None:
+def _check_complete(
+    species: tuple[Species, ...], pair_potentials: Mapping[tuple[Species, Species], PairPotential]
+) -> None:
     """Check that the species do not repeat, that every pair of them has
     exactly one potential, and that no other pair has one.
 
@@ -82,7 +82,11 @@ class Model:
             ``pair_potentials`` is not a ``PairPotential`` instance.
     """
 
-    def __init__(self, species: Sequence[Species], pair_potentials: PairPotentials) -> None:
+    def __init__(
+        self,
+        species: Sequence[Species],
+        pair_potentials: Mapping[tuple[Species, Species], PairPotential],
+    ) -> None:
         if isinstance(species, Species | str):
             raise TypeError(
                 f"species must be a sequence of Species, such as ({species!r},); "
@@ -110,7 +114,7 @@ class Model:
         return self._species
 
     @property
-    def pair_potentials(self) -> PairPotentials:
+    def pair_potentials(self) -> Mapping[tuple[Species, Species], PairPotential]:
         """The potential between each pair of species, as a read-only mapping."""
         return self._pair_potentials
 

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -12,22 +12,8 @@ from pylj.potentials import PairPotential, Species
 def _check_complete(
     species: tuple[Species, ...], pair_potentials: Mapping[tuple[Species, Species], PairPotential]
 ) -> None:
-    """Check that the species do not repeat, that every pair of them has
-    exactly one potential, and that no other pair has one.
-
-    Raises:
-        ValueError: If ``species`` is empty or repeats a species, a key of
-            ``pair_potentials`` is not a pair, an entry of
-            ``pair_potentials`` names something that is not one of the
-            species, a pair of species has no entry in either order, or a
-            cross pair has one in both orders.
-        TypeError: If a value in ``pair_potentials`` is not a
-            ``PairPotential`` instance, such as the class itself.
-    """
-    if not species:
-        raise ValueError("species must name at least one Species")
-    if len(set(species)) != len(species):
-        raise ValueError("species must not repeat: two Species that compare equal are one species")
+    """Check that every pair of the species has exactly one potential and that
+    no other pair has one."""
     for pair in pair_potentials:
         if not isinstance(pair, tuple) or len(pair) != 2:
             raise ValueError(
@@ -105,6 +91,12 @@ class Model:
                 f"{{(argon, argon): potential}}, not {pair_potentials!r}; for one species, "
                 "Model.single(species, potential) builds the model"
             )
+        if not self._species:
+            raise ValueError("species must name at least one Species")
+        if len(set(self._species)) != len(self._species):
+            raise ValueError(
+                "species must not repeat: two Species that compare equal are one species"
+            )
         self._pair_potentials = MappingProxyType(dict(pair_potentials))
         _check_complete(self._species, self._pair_potentials)
 
@@ -125,9 +117,6 @@ class Model:
         Args:
             species: The one species.
             potential: The potential between two atoms of it.
-
-        Returns:
-            The model.
         """
         return cls((species,), {(species, species): potential})
 

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -2,22 +2,24 @@
 between each pair of them."""
 
 import itertools
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
 from typing import Self
 
 from pylj.potentials import PairPotential, Species
 
+PairPotentials = Mapping[tuple[Species, Species], PairPotential]
 
-def _check_complete(
-    species: tuple[Species, ...], pair_potentials: Mapping[tuple[Species, Species], PairPotential]
-) -> None:
-    """Check that every pair of species has exactly one potential.
+
+def _check_complete(species: tuple[Species, ...], pair_potentials: PairPotentials) -> None:
+    """Check that the species do not repeat, that every pair of them has
+    exactly one potential, and that no other pair has one.
 
     Raises:
-        ValueError: If ``species`` is empty or repeats a species, a pair of
-            species has no entry in ``pair_potentials`` in either order, or
-            a cross pair has one in both orders.
+        ValueError: If ``species`` is empty or repeats a species, an entry of
+            ``pair_potentials`` names something that is not one of the
+            species, a pair of species has no entry in either order, or a
+            cross pair has one in both orders.
         TypeError: If a value in ``pair_potentials`` is not a
             ``PairPotential`` instance, such as the class itself.
     """
@@ -25,6 +27,13 @@ def _check_complete(
         raise ValueError("species must name at least one Species")
     if len(set(species)) != len(species):
         raise ValueError("species must not repeat: two Species that compare equal are one species")
+    for pair in pair_potentials:
+        for one in pair:
+            if one not in species:
+                raise ValueError(
+                    f"pair_potentials has an entry for {pair}, but {one!r} is not one of "
+                    f"the species {species}"
+                )
     for one, other in itertools.combinations_with_replacement(species, 2):
         if (one, other) not in pair_potentials and (other, one) not in pair_potentials:
             raise ValueError(f"pair_potentials has no entry for the pair {one} and {other}")
@@ -42,48 +51,76 @@ def _check_complete(
             )
 
 
-@dataclass(frozen=True)
 class Model:
     """The species in a simulation and the potential between each pair of them.
 
     Every pair of species, including each species with itself, has one
     entry in ``pair_potentials``, keyed by the two species in either order.
-    ``single`` builds the model for one species.
+    ``single`` builds the model for one species. A model does not change
+    after it is built: ``species`` and ``pair_potentials`` are read-only.
 
     Args:
-        species: The species. Atoms are assigned to them in turn when a
-            configuration is placed.
+        species: The species, as any sequence of ``Species``. Atoms are
+            assigned to them in turn when a configuration is placed.
         pair_potentials: The potential between each pair of species.
 
     Raises:
-        ValueError: If ``species`` is empty or repeats a species, a pair of
-            species has no potential, or a cross pair is given in both
-            orders.
-        TypeError: If a value in ``pair_potentials`` is not a
+        ValueError: If ``species`` is empty or repeats a species, an entry
+            of ``pair_potentials`` names something that is not one of the
+            species, a pair of species has no potential, or a cross pair is
+            given in both orders.
+        TypeError: If ``species`` is a single ``Species`` rather than a
+            sequence, or a value in ``pair_potentials`` is not a
             ``PairPotential`` instance.
     """
 
-    species: tuple[Species, ...]
-    pair_potentials: Mapping[tuple[Species, Species], PairPotential]
+    def __init__(self, species: Sequence[Species], pair_potentials: PairPotentials) -> None:
+        if isinstance(species, Species):
+            raise TypeError(
+                f"species must be a sequence of Species, such as ({species.name or 'argon'},); "
+                "for one species, Model.single(species, potential) builds the model"
+            )
+        self._species = tuple(species)
+        self._pair_potentials = MappingProxyType(dict(pair_potentials))
+        _check_complete(self._species, self._pair_potentials)
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "pair_potentials", dict(self.pair_potentials))
-        _check_complete(self.species, self.pair_potentials)
+    @property
+    def species(self) -> tuple[Species, ...]:
+        """The species, as a tuple, in the order atoms are assigned to them."""
+        return self._species
+
+    @property
+    def pair_potentials(self) -> PairPotentials:
+        """The potential between each pair of species, as a read-only mapping."""
+        return self._pair_potentials
 
     @classmethod
     def single(cls, species: Species, potential: PairPotential) -> Self:
-        """The model for one species interacting through one potential."""
+        """Build the model for one species.
+
+        Args:
+            species: The one species.
+            potential: The potential between two atoms of it.
+
+        Returns:
+            The model.
+        """
         return cls((species,), {(species, species): potential})
 
     def potential(self, one: Species, other: Species) -> PairPotential:
-        """Return the potential acting between two species, in either order.
+        """Return the potential between two species.
+
+        The pair may be given in either order.
 
         Raises:
             KeyError: If either species is not in the model.
         """
         for species in (one, other):
-            if species not in self.species:
-                raise KeyError(f"{species.name or species} is not a species in this model")
-        if (one, other) in self.pair_potentials:
-            return self.pair_potentials[(one, other)]
-        return self.pair_potentials[(other, one)]
+            if species not in self._species:
+                raise KeyError(f"{species!r} is not a species in this model")
+        if (one, other) in self._pair_potentials:
+            return self._pair_potentials[(one, other)]
+        return self._pair_potentials[(other, one)]
+
+    def __repr__(self) -> str:
+        return f"Model(species={self._species!r}, pair_potentials={dict(self._pair_potentials)!r})"

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -75,7 +75,8 @@ class Model:
     ) -> None:
         if isinstance(species, Species | str):
             raise TypeError(
-                f"species must be a sequence of Species, such as ({species!r},); "
+                "species must be a sequence of Species, such as "
+                f"(Species(mass=39.948, name='argon'),), not {species!r}; "
                 "for one species, Model.single(species, potential) builds the model"
             )
         self._species = tuple(species)

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -1,0 +1,86 @@
+"""The physical model a simulation runs: the species and the potential
+between each pair of them."""
+
+import itertools
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from pylj.potentials import PairPotential, Species
+
+
+def _check_complete(
+    species: tuple[Species, ...], pair_potentials: Mapping[tuple[Species, Species], PairPotential]
+) -> None:
+    """Check that every pair of species has exactly one potential.
+
+    Raises:
+        ValueError: If ``species`` is empty, a pair of species has no entry
+            in ``pair_potentials`` in either order, or a cross pair has one
+            in both orders.
+        TypeError: If a value in ``pair_potentials`` is not a
+            ``PairPotential`` instance, such as the class itself.
+    """
+    if not species:
+        raise ValueError("species must name at least one Species")
+    for one, other in itertools.combinations_with_replacement(species, 2):
+        if (one, other) not in pair_potentials and (other, one) not in pair_potentials:
+            raise ValueError(f"pair_potentials has no entry for the pair {one} and {other}")
+    for one, other in itertools.combinations(species, 2):
+        if (one, other) in pair_potentials and (other, one) in pair_potentials:
+            raise ValueError(
+                f"pair_potentials has the pair {one} and {other} in both orders; "
+                "give each unordered pair once"
+            )
+    for pair, potential in pair_potentials.items():
+        if not isinstance(potential, PairPotential):
+            raise TypeError(
+                f"pair_potentials[{pair}] must be a PairPotential instance, such as "
+                f"LennardJones(epsilon=..., sigma=...), not {potential!r}"
+            )
+
+
+@dataclass(frozen=True)
+class Model:
+    """The species in a simulation and the potential between each pair of them.
+
+    Every pair of species, including each species with itself, has one
+    entry in ``pair_potentials``, keyed by the two species in either order.
+    ``single`` builds the model for one species.
+
+    Args:
+        species: The species. Atoms are assigned to them in turn when a
+            configuration is placed.
+        pair_potentials: The potential between each pair of species.
+
+    Raises:
+        ValueError: If ``species`` is empty, a pair of species has no
+            potential, or a cross pair is given in both orders.
+        TypeError: If a value in ``pair_potentials`` is not a
+            ``PairPotential`` instance.
+    """
+
+    species: tuple[Species, ...]
+    pair_potentials: Mapping[tuple[Species, Species], PairPotential]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "pair_potentials", dict(self.pair_potentials))
+        _check_complete(self.species, self.pair_potentials)
+
+    @classmethod
+    def single(cls, species: Species, potential: PairPotential) -> "Model":
+        """The model for one species interacting through one potential."""
+        return cls((species,), {(species, species): potential})
+
+    def potential(self, one: Species, other: Species) -> PairPotential:
+        """Return the potential acting between two species, in either order.
+
+        Raises:
+            KeyError: If either species is not in the model.
+        """
+        if (one, other) in self.pair_potentials:
+            return self.pair_potentials[(one, other)]
+        if (other, one) in self.pair_potentials:
+            return self.pair_potentials[(other, one)]
+        raise KeyError(
+            f"The model has no potential for {one.name or 'atoms'} and {other.name or 'atoms'}"
+        )

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -4,6 +4,7 @@ between each pair of them."""
 import itertools
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Self
 
 from pylj.potentials import PairPotential, Species
 
@@ -14,14 +15,16 @@ def _check_complete(
     """Check that every pair of species has exactly one potential.
 
     Raises:
-        ValueError: If ``species`` is empty, a pair of species has no entry
-            in ``pair_potentials`` in either order, or a cross pair has one
-            in both orders.
+        ValueError: If ``species`` is empty or repeats a species, a pair of
+            species has no entry in ``pair_potentials`` in either order, or
+            a cross pair has one in both orders.
         TypeError: If a value in ``pair_potentials`` is not a
             ``PairPotential`` instance, such as the class itself.
     """
     if not species:
         raise ValueError("species must name at least one Species")
+    if len(set(species)) != len(species):
+        raise ValueError("species must not repeat: two Species that compare equal are one species")
     for one, other in itertools.combinations_with_replacement(species, 2):
         if (one, other) not in pair_potentials and (other, one) not in pair_potentials:
             raise ValueError(f"pair_potentials has no entry for the pair {one} and {other}")
@@ -53,8 +56,9 @@ class Model:
         pair_potentials: The potential between each pair of species.
 
     Raises:
-        ValueError: If ``species`` is empty, a pair of species has no
-            potential, or a cross pair is given in both orders.
+        ValueError: If ``species`` is empty or repeats a species, a pair of
+            species has no potential, or a cross pair is given in both
+            orders.
         TypeError: If a value in ``pair_potentials`` is not a
             ``PairPotential`` instance.
     """
@@ -67,7 +71,7 @@ class Model:
         _check_complete(self.species, self.pair_potentials)
 
     @classmethod
-    def single(cls, species: Species, potential: PairPotential) -> "Model":
+    def single(cls, species: Species, potential: PairPotential) -> Self:
         """The model for one species interacting through one potential."""
         return cls((species,), {(species, species): potential})
 
@@ -77,10 +81,9 @@ class Model:
         Raises:
             KeyError: If either species is not in the model.
         """
+        for species in (one, other):
+            if species not in self.species:
+                raise KeyError(f"{species.name or species} is not a species in this model")
         if (one, other) in self.pair_potentials:
             return self.pair_potentials[(one, other)]
-        if (other, one) in self.pair_potentials:
-            return self.pair_potentials[(other, one)]
-        raise KeyError(
-            f"The model has no potential for {one.name or 'atoms'} and {other.name or 'atoms'}"
-        )
+        return self.pair_potentials[(other, one)]

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -1,42 +1,11 @@
-"""Calculations over every pair of atoms at once: finding the potential
-that acts between two species, grouping the atom pairs by the species they
-join, applying the minimum image convention, and getting the pressure from the
-virial."""
+"""Calculations over every pair of atoms at once: grouping the atom pairs by
+the species they join, applying the minimum image convention, and getting the
+pressure from the virial."""
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 
 import numpy as np
 from numpy.typing import NDArray
-
-from pylj.potentials import PairPotential, Species
-
-#: The potential acting between each pair of species, keyed by the two
-#: species in either order.
-PairPotentials = Mapping[tuple[Species, Species], PairPotential]
-
-
-def pair_potential(
-    pair_potentials: PairPotentials, species_1: Species, species_2: Species
-) -> PairPotential:
-    """Return the potential acting between two species.
-
-    The mapping is keyed by unordered pairs, so the two species are looked
-    up in either order.
-
-    Args:
-        pair_potentials: The potential between each pair of species.
-        species_1: One species of the pair.
-        species_2: The other species of the pair.
-
-    Returns:
-        The potential for the pair.
-
-    Raises:
-        KeyError: If the mapping has no entry for the pair in either order.
-    """
-    if (species_1, species_2) in pair_potentials:
-        return pair_potentials[(species_1, species_2)]
-    return pair_potentials[(species_2, species_1)]
 
 
 def species_pairs(

--- a/pylj/placement.py
+++ b/pylj/placement.py
@@ -164,12 +164,11 @@ def place(
             "hold more than one atom, and above 600 the atoms are too small to be "
             "seen in the viewer."
         )
-    species = model.species
     box_m = box * 1e-10
     cut_off_m = _resolve_cut_off(box_m, None if cut_off is None else cut_off * 1e-10)
     _check_potentials_at_the_cut_off(model, cut_off_m, temperature, box_m)
     if init_conf == "square":
-        configuration = place_square(number_of_atoms, species, box_m)
+        configuration = place_square(number_of_atoms, model.species, box_m)
     elif init_conf == "metropolis":
         configuration = place_metropolis(
             number_of_atoms,

--- a/pylj/placement.py
+++ b/pylj/placement.py
@@ -1,17 +1,11 @@
 """The placement of initial configurations."""
 
-from collections.abc import Sequence
-
 import numpy as np
 
 from pylj.configuration import Configuration
-from pylj.pairwise import PairPotentials
+from pylj.model import Model
 from pylj.potentials import Species, check_positive_finite
-from pylj.simulation import (
-    _check_pair_potentials,
-    _check_potentials_at_the_cut_off,
-    _resolve_cut_off,
-)
+from pylj.simulation import _check_potentials_at_the_cut_off, _resolve_cut_off
 
 #: Number of trial positions tried for a single atom by Metropolis
 #: placement before it gives up and raises ``ValueError``.
@@ -50,7 +44,7 @@ def place_metropolis(
     number_of_atoms: int,
     species: tuple[Species, ...],
     box: float,
-    pair_potentials: PairPotentials,
+    model: Model,
     cut_off: float,
     placement_temperature: float,
     rng: np.random.Generator,
@@ -74,7 +68,7 @@ def place_metropolis(
         number_of_atoms: The number of atoms.
         species: The species, assigned to the atoms in turn.
         box: The side length of the box, in metres.
-        pair_potentials: The potential between each pair of species.
+        model: The species and the potential between each pair of them.
         cut_off: The cut-off, in metres.
         placement_temperature: The temperature of the acceptance, in kelvin.
         rng: The generator to draw trial positions and acceptances from.
@@ -98,7 +92,7 @@ def place_metropolis(
     for i in range(number_of_atoms):
         for _attempt in range(PLACEMENT_ATTEMPTS):
             trial = rng.uniform(0, box, size=2)
-            energy = placed.insertion_energy(trial, int(species_index[i]), pair_potentials, cut_off)
+            energy = placed.insertion_energy(trial, int(species_index[i]), model, cut_off)
             if accept(energy, placement_temperature, rng=rng):
                 placed = placed.replace(
                     position=np.vstack([placed.position, trial]),
@@ -121,8 +115,7 @@ def place(
     temperature: float,
     box: float,
     *,
-    species: Sequence[Species],
-    pair_potentials: PairPotentials,
+    model: Model,
     init_conf: str,
     placement_temperature: float | None,
     cut_off: float | None,
@@ -130,16 +123,16 @@ def place(
 ) -> tuple[Configuration, float]:
     """Build the initial configuration for a simulation factory.
 
-    Takes the box and cut-off in Angstrom, as the factories do, validates
-    the model, checks the potentials at the cut-off before any placement is
-    attempted, and places the atoms.
+    Takes the box and cut-off in Angstrom, as the factories do, checks the
+    potentials at the cut-off before any placement is attempted, and places
+    the atoms.
 
     Args:
         number_of_atoms: The number of atoms.
         temperature: The temperature of the run, in kelvin.
         box: The side length of the box, in Angstrom, from 4 to 600.
-        species: The species, assigned to the atoms in turn.
-        pair_potentials: The potential between each pair of species.
+        model: The species, assigned to the atoms in turn, and the potential
+            between each pair of them.
         init_conf: ``'square'`` for a lattice or ``'metropolis'`` for
             sequential Metropolis insertion.
         placement_temperature: The temperature of the Metropolis acceptance
@@ -155,10 +148,9 @@ def place(
     Raises:
         ValueError: If no atoms are requested, a temperature is
             not positive and finite, the box is outside 4 to 600 Angstrom,
-            the cut-off exceeds half the box, the model is incomplete, a
-            potential has not died away at the cut-off, ``init_conf`` is
-            unknown, or Metropolis placement exhausts its trial budget.
-        TypeError: If a pair potential is not a ``PairPotential`` instance.
+            the cut-off exceeds half the box, a potential has not died away
+            at the cut-off, ``init_conf`` is unknown, or Metropolis placement
+            exhausts its trial budget.
     """
     if number_of_atoms < 1:
         raise ValueError("A simulation needs at least one atom")
@@ -172,11 +164,10 @@ def place(
             "hold more than one atom, and above 600 the atoms are too small to be "
             "seen in the viewer."
         )
-    species = tuple(species)
-    _check_pair_potentials(species, pair_potentials)
+    species = model.species
     box_m = box * 1e-10
     cut_off_m = _resolve_cut_off(box_m, None if cut_off is None else cut_off * 1e-10)
-    _check_potentials_at_the_cut_off(species, pair_potentials, cut_off_m, temperature, box_m)
+    _check_potentials_at_the_cut_off(model, cut_off_m, temperature, box_m)
     if init_conf == "square":
         configuration = place_square(number_of_atoms, species, box_m)
     elif init_conf == "metropolis":
@@ -184,7 +175,7 @@ def place(
             number_of_atoms,
             species,
             box_m,
-            pair_potentials,
+            model,
             cut_off_m,
             placement_temperature,
             rng,

--- a/pylj/placement.py
+++ b/pylj/placement.py
@@ -42,7 +42,6 @@ def place_square(number_of_atoms: int, species: tuple[Species, ...], box: float)
 
 def place_metropolis(
     number_of_atoms: int,
-    species: tuple[Species, ...],
     box: float,
     model: Model,
     cut_off: float,
@@ -66,9 +65,9 @@ def place_metropolis(
 
     Args:
         number_of_atoms: The number of atoms.
-        species: The species, assigned to the atoms in turn.
         box: The side length of the box, in metres.
-        model: The species and the potential between each pair of them.
+        model: The species, assigned to the atoms in turn, and the potential
+            between each pair of them.
         cut_off: The cut-off, in metres.
         placement_temperature: The temperature of the acceptance, in kelvin.
         rng: The generator to draw trial positions and acceptances from.
@@ -87,6 +86,7 @@ def place_metropolis(
     # imported here rather than at the top of the module.
     from pylj.mc import accept
 
+    species = model.species
     species_index = np.arange(number_of_atoms) % len(species)
     placed = Configuration(np.zeros((0, 2)), species, species_index[:0], box)
     for i in range(number_of_atoms):
@@ -173,7 +173,6 @@ def place(
     elif init_conf == "metropolis":
         configuration = place_metropolis(
             number_of_atoms,
-            species,
             box_m,
             model,
             cut_off_m,

--- a/pylj/potentials.py
+++ b/pylj/potentials.py
@@ -92,6 +92,9 @@ class LennardJones(PairPotential):
         self.epsilon = epsilon
         self.sigma = sigma
 
+    def __repr__(self) -> str:
+        return f"LennardJones(epsilon={self.epsilon!r}, sigma={self.sigma!r})"
+
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)
         with np.errstate(divide="ignore"):
@@ -144,6 +147,9 @@ class Buckingham(PairPotential):
         self.b = b
         self.c = c
         self.min_separation = self._find_barrier()
+
+    def __repr__(self) -> str:
+        return f"Buckingham(a={self.a!r}, b={self.b!r}, c={self.c!r})"
 
     def _form(self, dr: NDArray[np.float64]) -> NDArray[np.float64]:
         return self.a * np.exp(-self.b * dr) - self.c / dr**6
@@ -222,6 +228,12 @@ class SquareWell(PairPotential):
         self.sigma = sigma
         self.lambda_ = lambda_
         self.max_val = max_val
+
+    def __repr__(self) -> str:
+        return (
+            f"SquareWell(epsilon={self.epsilon!r}, sigma={self.sigma!r}, "
+            f"lambda_={self.lambda_!r}, max_val={self.max_val!r})"
+        )
 
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)

--- a/pylj/potentials.py
+++ b/pylj/potentials.py
@@ -230,10 +230,13 @@ class SquareWell(PairPotential):
         self.max_val = max_val
 
     def __repr__(self) -> str:
-        return (
+        call = (
             f"SquareWell(epsilon={self.epsilon!r}, sigma={self.sigma!r}, "
-            f"lambda_={self.lambda_!r}, max_val={self.max_val!r})"
+            f"lambda_={self.lambda_!r}"
         )
+        if np.isfinite(self.max_val):
+            call += f", max_val={self.max_val!r}"
+        return call + ")"
 
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
         dr = np.asarray(dr, dtype=float)

--- a/pylj/sample/panes.py
+++ b/pylj/sample/panes.py
@@ -204,10 +204,7 @@ def _drawn_diameters(
     """
     species = simulation.configuration.species
     if diameter is None:
-        return [
-            _potential_minimum(pairwise.pair_potential(simulation.pair_potentials, one, one))
-            for one in species
-        ]
+        return [_potential_minimum(simulation.model.potential(one, one)) for one in species]
     if isinstance(diameter, Iterable):
         values = [float(d) for d in diameter]
     else:

--- a/pylj/simulation.py
+++ b/pylj/simulation.py
@@ -166,7 +166,7 @@ class Samples:
 
 
 class Simulation(ABC):
-    """A simulation: a configuration, the interaction law, the numerical choices, and
+    """A simulation: a configuration, the model, the numerical choices, and
     the machinery that evolves the configuration and measures it.
 
     ``MDSimulation`` and ``MCSimulation`` add ``step`` and ``sample`` to this

--- a/pylj/simulation.py
+++ b/pylj/simulation.py
@@ -2,7 +2,6 @@
 samples, and the base class the simulations share."""
 
 import copy
-import itertools
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from typing import Self
@@ -46,8 +45,7 @@ def _check_potentials_at_the_cut_off(
     if from_box:
         where += " (half the box)"
     remedy = "Use a larger box" if from_box else "Use a larger box or cut-off"
-    for one, other in itertools.combinations_with_replacement(model.species, 2):
-        potential = model.potential(one, other)
+    for (one, other), potential in model.pair_potentials.items():
         energy = float(potential.energies(np.array([cut_off]))[0])
         pair = (
             f"{type(potential).__name__} between {one.name or 'atoms'} and {other.name or 'atoms'}"

--- a/pylj/simulation.py
+++ b/pylj/simulation.py
@@ -4,63 +4,24 @@ samples, and the base class the simulations share."""
 import copy
 import itertools
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
 from dataclasses import dataclass, field, fields
 from typing import Self
 
 import numpy as np
 from numpy.typing import NDArray
 
-from pylj import pairwise
 from pylj.configuration import Configuration
 from pylj.constants import BOLTZMANN
-from pylj.pairwise import PairPotentials
-from pylj.potentials import PairPotential, Species, check_positive_finite
+from pylj.model import Model
+from pylj.potentials import check_positive_finite
 
 #: Largest potential energy per atom, in units of k_B T, accepted for an
 #: initial configuration.
 INITIAL_ENERGY_LIMIT = 10.0
 
 
-def _check_pair_potentials(species: Sequence[Species], pair_potentials: PairPotentials) -> None:
-    """Check that a model is complete.
-
-    Args:
-        species: The species in the model.
-        pair_potentials: The potential between each pair of species.
-
-    Raises:
-        ValueError: If ``species`` is empty, a pair of species has no entry
-            in ``pair_potentials`` in either order, or a cross pair has one
-            in both orders.
-        TypeError: If a value in ``pair_potentials`` is not a
-            ``PairPotential`` instance, such as the class itself.
-    """
-    if not species:
-        raise ValueError("species must name at least one Species")
-    for one, other in itertools.combinations_with_replacement(species, 2):
-        if (one, other) not in pair_potentials and (other, one) not in pair_potentials:
-            raise ValueError(f"pair_potentials has no entry for the pair {one} and {other}")
-    for one, other in itertools.combinations(species, 2):
-        if (one, other) in pair_potentials and (other, one) in pair_potentials:
-            raise ValueError(
-                f"pair_potentials has the pair {one} and {other} in both orders; "
-                "give each unordered pair once"
-            )
-    for pair, potential in pair_potentials.items():
-        if not isinstance(potential, PairPotential):
-            raise TypeError(
-                f"pair_potentials[{pair}] must be a PairPotential instance, such as "
-                f"LennardJones(epsilon=..., sigma=...), not {potential!r}"
-            )
-
-
 def _check_potentials_at_the_cut_off(
-    species: Sequence[Species],
-    pair_potentials: PairPotentials,
-    cut_off: float,
-    temperature: float,
-    box: float,
+    model: Model, cut_off: float, temperature: float, box: float
 ) -> None:
     """Check that every pair potential has died away at the cut-off.
 
@@ -69,8 +30,7 @@ def _check_potentials_at_the_cut_off(
     within ``k_B T`` of zero.
 
     Args:
-        species: The species in the model.
-        pair_potentials: The potential between each pair of species.
+        model: The species and the potential between each pair of them.
         cut_off: The cut-off, in metres.
         temperature: The temperature, in kelvin.
         box: The side length of the box, in metres. The cut-off can be no
@@ -86,8 +46,8 @@ def _check_potentials_at_the_cut_off(
     if from_box:
         where += " (half the box)"
     remedy = "Use a larger box" if from_box else "Use a larger box or cut-off"
-    for one, other in itertools.combinations_with_replacement(species, 2):
-        potential = pairwise.pair_potential(pair_potentials, one, other)
+    for one, other in itertools.combinations_with_replacement(model.species, 2):
+        potential = model.potential(one, other)
         energy = float(potential.energies(np.array([cut_off]))[0])
         pair = (
             f"{type(potential).__name__} between {one.name or 'atoms'} and {other.name or 'atoms'}"
@@ -211,15 +171,14 @@ class Simulation(ABC):
 
     ``MDSimulation`` and ``MCSimulation`` add ``step`` and ``sample`` to this
     class. The constructor takes a configuration that has already been built,
-    in SI units. To start from a description of the system instead, how many
-    atoms, which species and which potentials, use the ``initialise``
-    method of one of those subclasses, which builds the configuration for you.
+    in SI units. To start from a model and a number of atoms instead, use the
+    ``initialise`` method of one of those subclasses, which builds the
+    configuration for you.
 
     Args:
         configuration: The starting configuration.
-        pair_potentials: The potential between each pair of species, keyed
-            by the two species in either order. Every pair, including each
-            species with itself, needs an entry.
+        model: The species and the potential between each pair of them, a
+            :class:`~pylj.model.Model`.
         cut_off: The separation, in metres, beyond which a pair's
             interaction is taken as negligible. By default 15 Angstrom or
             half the box, whichever is smaller; it may not exceed half the
@@ -229,7 +188,7 @@ class Simulation(ABC):
 
     Attributes:
         configuration: The current configuration.
-        pair_potentials: The interaction law.
+        model: The model.
         cut_off: The cut-off, in metres.
         rng: The random number generator for this simulation.
         steps: The number of steps taken.
@@ -237,22 +196,23 @@ class Simulation(ABC):
             with the record of what they measure.
 
     Raises:
-        ValueError: If the model is incomplete or the cut-off exceeds half
-            the box.
-        TypeError: If a pair potential is not a ``PairPotential`` instance.
+        ValueError: If a species in the configuration is not in the model,
+            or the cut-off exceeds half the box.
     """
 
     def __init__(
         self,
         configuration: Configuration,
-        pair_potentials: PairPotentials,
+        model: Model,
         *,
         cut_off: float | None = None,
         seed: int | None = None,
     ) -> None:
-        _check_pair_potentials(configuration.species, pair_potentials)
+        for one in configuration.species:
+            if one not in model.species:
+                raise ValueError(f"The configuration has species {one}, which is not in the model")
         self.configuration = configuration
-        self.pair_potentials = dict(pair_potentials)
+        self.model = model
         self.cut_off = _resolve_cut_off(configuration.box, cut_off)
         self.rng = np.random.default_rng(seed)
         self.steps = 0
@@ -269,7 +229,7 @@ class Simulation(ABC):
     def restart(self) -> Self:
         """A new simulation that continues from the current configuration.
 
-        The new simulation shares the interaction law, the numerical choices
+        The new simulation shares the model, the numerical choices
         and every other attribute with this one. Its random number generator
         starts from a copy of this one's state, so what this simulation draws
         next has no effect on the new one. The new simulation starts with

--- a/pylj/tests/argon.py
+++ b/pylj/tests/argon.py
@@ -1,18 +1,11 @@
 """The species and pair potentials shared across the test suite.
 
-``ARGON_MODEL`` and ``MIXTURE_MODEL`` unpack into the ``species`` and
-``pair_potentials`` keywords of the ``initialise`` factories.
+``ARGON_MODEL`` and ``MIXTURE_MODEL`` are ``Model`` instances for the
+``initialise`` factories.
 """
 
-from typing import TypedDict
-
-from pylj.potentials import Buckingham, LennardJones, PairPotential, Species, SquareWell
-
-
-class Model(TypedDict):
-    species: list[Species]
-    pair_potentials: dict[tuple[Species, Species], PairPotential]
-
+from pylj.model import Model
+from pylj.potentials import Buckingham, LennardJones, Species, SquareWell
 
 ARGON = Species(mass=39.948, name="argon")
 # A heavier atom with a 5 Angstrom core and the argon well depth.
@@ -22,36 +15,26 @@ LJ_ARGON = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
 LJ_LARGER = LennardJones(epsilon=1.577e-21, sigma=5.0e-10)
 LJ_ARGON_LARGER = LennardJones(epsilon=1.577e-21, sigma=4.186e-10)
 
-ARGON_MODEL: Model = {
-    "species": [ARGON],
-    "pair_potentials": {(ARGON, ARGON): LJ_ARGON},
-}
+ARGON_MODEL = Model.single(ARGON, LJ_ARGON)
 # A Buckingham form for argon, with its short-range barrier, and so its
 # min_separation, at 0.78 Angstrom.
 BUCKINGHAM_ARGON = Buckingham(a=1.69e-15, b=3.66e10, c=1.02e-77)
-BUCKINGHAM_MODEL: Model = {
-    "species": [ARGON],
-    "pair_potentials": {(ARGON, ARGON): BUCKINGHAM_ARGON},
-}
+BUCKINGHAM_MODEL = Model.single(ARGON, BUCKINGHAM_ARGON)
 # A hard-core square well with a 3 Angstrom core and a well out to 4.5.
 WELL = SquareWell(epsilon=1.5e-21, sigma=3e-10, lambda_=1.5)
-WELL_MODEL: Model = {"species": [ARGON], "pair_potentials": {(ARGON, ARGON): WELL}}
+WELL_MODEL = Model.single(ARGON, WELL)
 
 # Hard cores of three different diameters, one per species pair.
-WELL_MIXTURE_MODEL: Model = {
-    "species": [ARGON, LARGER],
-    "pair_potentials": {
+WELL_MIXTURE_MODEL = Model(
+    (ARGON, LARGER),
+    {
         (ARGON, ARGON): WELL,
         (LARGER, LARGER): SquareWell(epsilon=1.5e-21, sigma=5e-10, lambda_=1.5),
         (ARGON, LARGER): SquareWell(epsilon=1.5e-21, sigma=4e-10, lambda_=1.5),
     },
-}
+)
 
-MIXTURE_MODEL: Model = {
-    "species": [ARGON, LARGER],
-    "pair_potentials": {
-        (ARGON, ARGON): LJ_ARGON,
-        (LARGER, LARGER): LJ_LARGER,
-        (ARGON, LARGER): LJ_ARGON_LARGER,
-    },
-}
+MIXTURE_MODEL = Model(
+    (ARGON, LARGER),
+    {(ARGON, ARGON): LJ_ARGON, (LARGER, LARGER): LJ_LARGER, (ARGON, LARGER): LJ_ARGON_LARGER},
+)

--- a/pylj/tests/test_configuration.py
+++ b/pylj/tests/test_configuration.py
@@ -139,7 +139,7 @@ class TestConfiguration(unittest.TestCase):
         rng = np.random.default_rng(1)
         n, box, cut_off = 8, 30e-10, 9e-10
         species_index = np.array([0, 1, 0, 1, 0, 1, 0, 1])
-        potentials = MIXTURE_MODEL
+        model = MIXTURE_MODEL
         full = configuration(
             rng.uniform(0, box, (n, 2)),
             species=MIXTURE_MODEL.species,
@@ -148,10 +148,10 @@ class TestConfiguration(unittest.TestCase):
         )
         without_last = full.without(n - 1)
         added = without_last.insertion_energy(
-            full.position[-1], int(species_index[-1]), potentials, cut_off
+            full.position[-1], int(species_index[-1]), model, cut_off
         )
-        difference = full.potential_energy(potentials, cut_off) - without_last.potential_energy(
-            potentials, cut_off
+        difference = full.potential_energy(model, cut_off) - without_last.potential_energy(
+            model, cut_off
         )
         assert_allclose(added, difference, rtol=1e-9)
 
@@ -168,7 +168,7 @@ class TestConfiguration(unittest.TestCase):
             species_index=species_index,
             box=box,
         )
-        potentials = MIXTURE_MODEL
+        model = MIXTURE_MODEL
         reference = np.zeros((n, 2))
         virial = 0.0
         for a in range(n - 1):
@@ -176,15 +176,15 @@ class TestConfiguration(unittest.TestCase):
                 separation = c.position[a] - c.position[b]
                 separation -= box * np.round(separation / box)
                 dr = np.linalg.norm(separation)
-                potential = potentials.potential(
+                potential = model.potential(
                     c.species[species_index[a]], c.species[species_index[b]]
                 )
                 force = potential.forces(dr)
                 reference[a] += force * separation / dr
                 reference[b] -= force * separation / dr
                 virial += force * dr
-        assert_allclose(c.forces(potentials, 1e-8), reference, rtol=1e-12)
-        assert_allclose(c.virial(potentials, 1e-8), virial, rtol=1e-12)
+        assert_allclose(c.forces(model, 1e-8), reference, rtol=1e-12)
+        assert_allclose(c.virial(model, 1e-8), virial, rtol=1e-12)
 
     def test_forces_are_equal_and_opposite_for_a_pair(self):
         c = configuration([[0.0, 0.0], [4e-10, 0.0]])
@@ -219,15 +219,15 @@ class TestConfiguration(unittest.TestCase):
         # Two argon 0.5 Angstrom apart, inside the Buckingham barrier: the
         # formula there is a deep negative number, but the pair is forbidden,
         # so the energy is infinite and asking for the force raises.
-        potentials = BUCKINGHAM_MODEL
+        model = BUCKINGHAM_MODEL
         c = configuration([[0.0, 0.0], [0.5e-10, 0.0]])
         self.assertLess(BUCKINGHAM_ARGON.energies(np.array([0.5e-10]))[0], 0.0)
-        self.assertEqual(c.pairs(potentials, 15e-10).energy[0], np.inf)
-        self.assertEqual(c.potential_energy(potentials, 15e-10), np.inf)
+        self.assertEqual(c.pairs(model, 15e-10).energy[0], np.inf)
+        self.assertEqual(c.potential_energy(model, 15e-10), np.inf)
         with self.assertRaisesRegex(ValueError, "unphysical"):
-            c.forces(potentials, 15e-10)
+            c.forces(model, 15e-10)
         with self.assertRaisesRegex(ValueError, "collapsed"):
-            c.virial(potentials, 15e-10)
+            c.virial(model, 15e-10)
 
     def test_insertion_energy_forbids_a_separation_where_the_potential_is_unphysical(self):
         c = configuration([[0.0, 0.0]])

--- a/pylj/tests/test_configuration.py
+++ b/pylj/tests/test_configuration.py
@@ -3,9 +3,9 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
-from pylj import pairwise
 from pylj.configuration import Configuration, MDConfiguration
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
+from pylj.model import Model
 from pylj.potentials import PairPotential
 from pylj.tests.argon import (
     ARGON,
@@ -46,8 +46,8 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(c, c)
         self.assertNotEqual(c, c.replace())
         self.assertNotEqual(
-            c.pairs(ARGON_MODEL["pair_potentials"], 15e-10),
-            c.pairs(ARGON_MODEL["pair_potentials"], 15e-10),
+            c.pairs(ARGON_MODEL, 15e-10),
+            c.pairs(ARGON_MODEL, 15e-10),
         )
 
     def test_holds_positions_species_and_box(self):
@@ -104,7 +104,7 @@ class TestConfiguration(unittest.TestCase):
         # argon-larger, argon-argon and larger-argon; a 6 Angstrom cut-off
         # drops the last.
         c = three_atoms([0, 1, 0])
-        pairs = c.pairs(MIXTURE_MODEL["pair_potentials"], 6e-10, forces=True)
+        pairs = c.pairs(MIXTURE_MODEL, 6e-10, forces=True)
         assert_almost_equal(pairs.distance * 1e10, [4.0, np.sqrt(26), np.sqrt(50)])
         expected = [
             LJ_ARGON_LARGER.energies(pairs.distance[0]),
@@ -120,19 +120,17 @@ class TestConfiguration(unittest.TestCase):
 
     def test_pairs_needs_no_force_from_the_potential(self):
         c = three_atoms()
-        pairs = c.pairs(WELL_MODEL["pair_potentials"], 15e-10)
+        pairs = c.pairs(WELL_MODEL, 15e-10)
         assert_almost_equal(pairs.energy * 1e21, [-1.5, 0.0, 0.0])
         self.assertIsNone(pairs.radial_force)
         with self.assertRaisesRegex(ValueError, "Monte Carlo"):
-            c.pairs(WELL_MODEL["pair_potentials"], 15e-10, forces=True)
+            c.pairs(WELL_MODEL, 15e-10, forces=True)
 
     def test_potential_energy_is_the_sum_of_the_pair_energies(self):
         # Pairs at 4, sqrt(26) and sqrt(50) Angstrom, all argon.
         c = three_atoms()
         expected = LJ_ARGON.energies(np.array([4e-10, np.sqrt(26) * 1e-10, np.sqrt(50) * 1e-10]))
-        assert_allclose(
-            c.potential_energy(ARGON_MODEL["pair_potentials"], 15e-10), expected.sum(), rtol=1e-12
-        )
+        assert_allclose(c.potential_energy(ARGON_MODEL, 15e-10), expected.sum(), rtol=1e-12)
 
     def test_insertion_energy_is_the_energy_the_atom_adds(self):
         # The same minimum image, species lookup and cut-off on both paths:
@@ -141,10 +139,10 @@ class TestConfiguration(unittest.TestCase):
         rng = np.random.default_rng(1)
         n, box, cut_off = 8, 30e-10, 9e-10
         species_index = np.array([0, 1, 0, 1, 0, 1, 0, 1])
-        potentials = MIXTURE_MODEL["pair_potentials"]
+        potentials = MIXTURE_MODEL
         full = configuration(
             rng.uniform(0, box, (n, 2)),
-            species=MIXTURE_MODEL["species"],
+            species=MIXTURE_MODEL.species,
             species_index=species_index,
             box=box,
         )
@@ -166,11 +164,11 @@ class TestConfiguration(unittest.TestCase):
         species_index = np.array([0, 0, 1, 1, 0, 1, 0, 1])
         c = configuration(
             rng.uniform(0, box, (n, 2)),
-            species=MIXTURE_MODEL["species"],
+            species=MIXTURE_MODEL.species,
             species_index=species_index,
             box=box,
         )
-        potentials = MIXTURE_MODEL["pair_potentials"]
+        potentials = MIXTURE_MODEL
         reference = np.zeros((n, 2))
         virial = 0.0
         for a in range(n - 1):
@@ -178,8 +176,8 @@ class TestConfiguration(unittest.TestCase):
                 separation = c.position[a] - c.position[b]
                 separation -= box * np.round(separation / box)
                 dr = np.linalg.norm(separation)
-                potential = pairwise.pair_potential(
-                    potentials, c.species[species_index[a]], c.species[species_index[b]]
+                potential = potentials.potential(
+                    c.species[species_index[a]], c.species[species_index[b]]
                 )
                 force = potential.forces(dr)
                 reference[a] += force * separation / dr
@@ -190,7 +188,7 @@ class TestConfiguration(unittest.TestCase):
 
     def test_forces_are_equal_and_opposite_for_a_pair(self):
         c = configuration([[0.0, 0.0], [4e-10, 0.0]])
-        force = c.forces(ARGON_MODEL["pair_potentials"], 15e-10)
+        force = c.forces(ARGON_MODEL, 15e-10)
         assert_allclose(force[0], -force[1])
         self.assertNotEqual(force[0, 0], 0.0)
         self.assertEqual(force[0, 1], 0.0)
@@ -203,7 +201,7 @@ class TestConfiguration(unittest.TestCase):
         c = three_atoms([1, 0, 0]).replace(
             position=np.array([[4e-10, 0.0], [0.0, 5e-10], [0.0, 20e-10]])
         )
-        energy = c.insertion_energy((0.0, 0.0), 0, MIXTURE_MODEL["pair_potentials"], 6e-10)
+        energy = c.insertion_energy((0.0, 0.0), 0, MIXTURE_MODEL, 6e-10)
         expected = (
             LJ_ARGON_LARGER.energies(np.array([4e-10]))[0] + LJ_ARGON.energies(np.array([5e-10]))[0]
         )
@@ -214,14 +212,14 @@ class TestConfiguration(unittest.TestCase):
         # away across the boundary, and one at 8 Angstrom is beyond a 6
         # Angstrom cut-off.
         c = configuration([[29e-10, 0.0], [8e-10, 0.0]])
-        energy = c.insertion_energy((0.0, 0.0), 0, ARGON_MODEL["pair_potentials"], 6e-10)
+        energy = c.insertion_energy((0.0, 0.0), 0, ARGON_MODEL, 6e-10)
         assert_allclose(energy, LJ_ARGON.energies(np.array([1e-10]))[0], rtol=1e-12)
 
     def test_pairs_forbid_a_separation_where_the_potential_is_unphysical(self):
         # Two argon 0.5 Angstrom apart, inside the Buckingham barrier: the
         # formula there is a deep negative number, but the pair is forbidden,
         # so the energy is infinite and asking for the force raises.
-        potentials = BUCKINGHAM_MODEL["pair_potentials"]
+        potentials = BUCKINGHAM_MODEL
         c = configuration([[0.0, 0.0], [0.5e-10, 0.0]])
         self.assertLess(BUCKINGHAM_ARGON.energies(np.array([0.5e-10]))[0], 0.0)
         self.assertEqual(c.pairs(potentials, 15e-10).energy[0], np.inf)
@@ -233,13 +231,13 @@ class TestConfiguration(unittest.TestCase):
 
     def test_insertion_energy_forbids_a_separation_where_the_potential_is_unphysical(self):
         c = configuration([[0.0, 0.0]])
-        energy = c.insertion_energy((0.5e-10, 0.0), 0, BUCKINGHAM_MODEL["pair_potentials"], 15e-10)
+        energy = c.insertion_energy((0.5e-10, 0.0), 0, BUCKINGHAM_MODEL, 15e-10)
         self.assertEqual(energy, np.inf)
 
     def test_insertion_energy_with_no_atoms_is_zero(self):
         empty = configuration(np.zeros((0, 2)))
         self.assertEqual(
-            empty.insertion_energy((1e-10, 1e-10), 0, ARGON_MODEL["pair_potentials"], 15e-10),
+            empty.insertion_energy((1e-10, 1e-10), 0, ARGON_MODEL, 15e-10),
             0.0,
         )
 
@@ -266,7 +264,7 @@ class TestConfiguration(unittest.TestCase):
             (ARGON, LARGER): GaussianCore(a=2.0, b=3.0),
         }
         c = three_atoms([0, 1, 0])
-        pairs = c.pairs(potentials, 15e-10, forces=True)
+        pairs = c.pairs(Model((ARGON, LARGER), potentials), 15e-10, forces=True)
         # pairs (0, 1), (0, 2), (1, 2) are argon-larger, argon-argon, larger-argon
         kinds = [(ARGON, LARGER), (ARGON, ARGON), (ARGON, LARGER)]
         by_pair = list(zip(pairs.distance, kinds, strict=True))

--- a/pylj/tests/test_configuration.py
+++ b/pylj/tests/test_configuration.py
@@ -139,7 +139,6 @@ class TestConfiguration(unittest.TestCase):
         rng = np.random.default_rng(1)
         n, box, cut_off = 8, 30e-10, 9e-10
         species_index = np.array([0, 1, 0, 1, 0, 1, 0, 1])
-        model = MIXTURE_MODEL
         full = configuration(
             rng.uniform(0, box, (n, 2)),
             species=MIXTURE_MODEL.species,
@@ -148,10 +147,10 @@ class TestConfiguration(unittest.TestCase):
         )
         without_last = full.without(n - 1)
         added = without_last.insertion_energy(
-            full.position[-1], int(species_index[-1]), model, cut_off
+            full.position[-1], int(species_index[-1]), MIXTURE_MODEL, cut_off
         )
-        difference = full.potential_energy(model, cut_off) - without_last.potential_energy(
-            model, cut_off
+        difference = full.potential_energy(MIXTURE_MODEL, cut_off) - without_last.potential_energy(
+            MIXTURE_MODEL, cut_off
         )
         assert_allclose(added, difference, rtol=1e-9)
 
@@ -168,7 +167,6 @@ class TestConfiguration(unittest.TestCase):
             species_index=species_index,
             box=box,
         )
-        model = MIXTURE_MODEL
         reference = np.zeros((n, 2))
         virial = 0.0
         for a in range(n - 1):
@@ -176,15 +174,15 @@ class TestConfiguration(unittest.TestCase):
                 separation = c.position[a] - c.position[b]
                 separation -= box * np.round(separation / box)
                 dr = np.linalg.norm(separation)
-                potential = model.potential(
+                potential = MIXTURE_MODEL.potential(
                     c.species[species_index[a]], c.species[species_index[b]]
                 )
                 force = potential.forces(dr)
                 reference[a] += force * separation / dr
                 reference[b] -= force * separation / dr
                 virial += force * dr
-        assert_allclose(c.forces(model, 1e-8), reference, rtol=1e-12)
-        assert_allclose(c.virial(model, 1e-8), virial, rtol=1e-12)
+        assert_allclose(c.forces(MIXTURE_MODEL, 1e-8), reference, rtol=1e-12)
+        assert_allclose(c.virial(MIXTURE_MODEL, 1e-8), virial, rtol=1e-12)
 
     def test_forces_are_equal_and_opposite_for_a_pair(self):
         c = configuration([[0.0, 0.0], [4e-10, 0.0]])
@@ -219,15 +217,14 @@ class TestConfiguration(unittest.TestCase):
         # Two argon 0.5 Angstrom apart, inside the Buckingham barrier: the
         # formula there is a deep negative number, but the pair is forbidden,
         # so the energy is infinite and asking for the force raises.
-        model = BUCKINGHAM_MODEL
         c = configuration([[0.0, 0.0], [0.5e-10, 0.0]])
         self.assertLess(BUCKINGHAM_ARGON.energies(np.array([0.5e-10]))[0], 0.0)
-        self.assertEqual(c.pairs(model, 15e-10).energy[0], np.inf)
-        self.assertEqual(c.potential_energy(model, 15e-10), np.inf)
+        self.assertEqual(c.pairs(BUCKINGHAM_MODEL, 15e-10).energy[0], np.inf)
+        self.assertEqual(c.potential_energy(BUCKINGHAM_MODEL, 15e-10), np.inf)
         with self.assertRaisesRegex(ValueError, "unphysical"):
-            c.forces(model, 15e-10)
+            c.forces(BUCKINGHAM_MODEL, 15e-10)
         with self.assertRaisesRegex(ValueError, "collapsed"):
-            c.virial(model, 15e-10)
+            c.virial(BUCKINGHAM_MODEL, 15e-10)
 
     def test_insertion_energy_forbids_a_separation_where_the_potential_is_unphysical(self):
         c = configuration([[0.0, 0.0]])

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -13,7 +13,7 @@ from pylj.tests.argon import ARGON_MODEL, LJ_ARGON, MIXTURE_MODEL, WELL_MODEL
 
 def total_energy(sim):
     """The exact total pair energy of the current configuration."""
-    return sim.configuration.potential_energy(sim.pair_potentials, sim.cut_off)
+    return sim.configuration.potential_energy(sim.model, sim.cut_off)
 
 
 class TestAccept(unittest.TestCase):
@@ -59,7 +59,7 @@ class TestAccept(unittest.TestCase):
 
 class TestInitialise(unittest.TestCase):
     def test_square_lattice_at_a_temperature(self):
-        a = MCSimulation.initialise(number_of_atoms=2, temperature=300, box=8, **ARGON_MODEL)
+        a = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=2, temperature=300, box=8)
         c = a.configuration
         self.assertEqual(c.number_of_atoms, 2)
         assert_almost_equal(c.box, 8e-10)
@@ -70,7 +70,7 @@ class TestInitialise(unittest.TestCase):
         self.assertEqual(a.accepted, 0)
 
     def test_sets_the_starting_energy(self):
-        a = MCSimulation.initialise(number_of_atoms=2, temperature=300, box=8, **ARGON_MODEL)
+        a = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=2, temperature=300, box=8)
         assert_almost_equal(a.energy, total_energy(a))
         self.assertNotEqual(a.energy, 0.0)
 
@@ -78,23 +78,21 @@ class TestInitialise(unittest.TestCase):
         for temperature in (0, -300, np.inf):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 MCSimulation.initialise(
-                    number_of_atoms=4, temperature=temperature, box=8, **ARGON_MODEL
+                    ARGON_MODEL, number_of_atoms=4, temperature=temperature, box=8
                 )
 
     def test_passes_the_placement_temperature_and_seed_through(self):
         with self.assertRaisesRegex(ValueError, "Could not place"):
             MCSimulation.initialise(
+                ARGON_MODEL,
                 number_of_atoms=50,
                 temperature=100,
                 box=27,
                 init_conf="metropolis",
                 placement_temperature=1.0,
                 seed=0,
-                **ARGON_MODEL,
             )
-        a = MCSimulation.initialise(
-            number_of_atoms=2, temperature=300, box=8, seed=5, **ARGON_MODEL
-        )
+        a = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=2, temperature=300, box=8, seed=5)
         self.assertEqual(a.rng.random(), np.random.default_rng(5).random())
 
     def test_refuses_a_lattice_inside_a_hard_core(self):
@@ -102,19 +100,19 @@ class TestInitialise(unittest.TestCase):
         # Angstrom apart, inside a 3 Angstrom hard core that the 5 Angstrom
         # cut-off clears: the lattice energy is infinite.
         with self.assertRaisesRegex(ValueError, "not finite"):
-            MCSimulation.initialise(number_of_atoms=16, temperature=300, box=10, **WELL_MODEL)
+            MCSimulation.initialise(WELL_MODEL, number_of_atoms=16, temperature=300, box=10)
 
     def test_one_atom_is_allowed(self):
-        a = MCSimulation.initialise(number_of_atoms=1, temperature=300, box=20, **ARGON_MODEL)
+        a = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=1, temperature=300, box=20)
         self.assertEqual(a.energy, 0.0)
 
 
 class TestConstructor(unittest.TestCase):
     def test_accepts_an_md_configuration(self):
         md_simulation = MDSimulation.initialise(
-            number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=4, temperature=100, box=20
         )
-        a = MCSimulation(md_simulation.configuration, ARGON_MODEL["pair_potentials"], 100)
+        a = MCSimulation(md_simulation.configuration, ARGON_MODEL, 100)
         self.assertIs(a.configuration, md_simulation.configuration)
         for _ in range(20):
             a.step()
@@ -124,7 +122,7 @@ class TestConstructor(unittest.TestCase):
 
     def test_validates_the_temperature_before_the_model(self):
         c = MDSimulation.initialise(
-            number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=4, temperature=100, box=20
         ).configuration
         with self.assertRaisesRegex(ValueError, "temperature must be positive"):
             MCSimulation(c, {}, -1)
@@ -136,9 +134,7 @@ class TestMoves(unittest.TestCase):
         # four lattice neighbours 4 Angstrom away, inside the well, and four
         # diagonal ones 5.66 Angstrom away, beyond it, so 18 pairs sit at
         # -epsilon. The cut-off, half the box, is 6 Angstrom.
-        a = MCSimulation.initialise(
-            number_of_atoms=9, temperature=300, box=12, seed=2, **WELL_MODEL
-        )
+        a = MCSimulation.initialise(WELL_MODEL, number_of_atoms=9, temperature=300, box=12, seed=2)
         assert_almost_equal(a.energy * 1e21, -27.0)
         overlaps = 0
         for _ in range(50):
@@ -155,7 +151,7 @@ class TestMoves(unittest.TestCase):
 
     def test_proposals_compare_by_identity(self):
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         proposal = a.propose()
         self.assertEqual(proposal, proposal)
@@ -164,7 +160,7 @@ class TestMoves(unittest.TestCase):
 
     def test_propose_leaves_the_configuration_untouched(self):
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         before = a.configuration
         position = before.position.copy()
@@ -176,7 +172,7 @@ class TestMoves(unittest.TestCase):
 
     def test_propose_moves_exactly_one_atom_inside_the_box(self):
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         proposal = a.propose()
         moved = np.any(proposal.position != a.configuration.position, axis=1)
@@ -189,26 +185,24 @@ class TestMoves(unittest.TestCase):
         # The mixture checks the moving atom's own species is used, so
         # the proposals must move atoms of both species.
         for model in (ARGON_MODEL, MIXTURE_MODEL):
-            a = MCSimulation.initialise(
-                number_of_atoms=16, temperature=300, box=40, seed=1, **model
-            )
+            a = MCSimulation.initialise(model, number_of_atoms=16, temperature=300, box=40, seed=1)
             moved_species = set()
             for _ in range(5):
                 proposal = a.propose()
                 trial = a.configuration.replace(position=proposal.position)
-                expected = trial.potential_energy(a.pair_potentials, a.cut_off) - total_energy(a)
+                expected = trial.potential_energy(a.model, a.cut_off) - total_energy(a)
                 np.testing.assert_allclose(proposal.energy_change, expected, rtol=1e-9, atol=1e-33)
                 moved = np.any(proposal.position != a.configuration.position, axis=1)
                 moved_species.add(int(a.configuration.species_index[moved][0]))
                 a.apply(proposal)
-            self.assertEqual(moved_species, set(range(len(model["species"]))))
+            self.assertEqual(moved_species, set(range(len(model.species))))
 
     def test_apply_refuses_a_proposal_from_an_earlier_configuration(self):
         # Two proposals made from the same configuration: applying the
         # second after the first would undo the first move and add an
         # energy change that no longer applies.
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         first, second = a.propose(), a.propose()
         a.apply(first)
@@ -219,7 +213,7 @@ class TestMoves(unittest.TestCase):
 
     def test_apply_updates_the_positions_and_the_energy(self):
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         proposal = a.propose()
         a.apply(proposal)
@@ -228,7 +222,7 @@ class TestMoves(unittest.TestCase):
 
     def test_step_proposes_decides_and_counts(self):
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         for _ in range(100):
             a.step()
@@ -239,7 +233,7 @@ class TestMoves(unittest.TestCase):
 
     def test_sample_sets_the_exact_energy_and_records_it(self):
         a = MCSimulation.initialise(
-            number_of_atoms=16, temperature=300, box=30, seed=1, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=16, temperature=300, box=30, seed=1
         )
         for _ in range(20):
             a.apply(a.propose())
@@ -253,12 +247,12 @@ class TestMoves(unittest.TestCase):
     def test_seeded_runs_are_identical(self):
         def run(seed):
             a = MCSimulation.initialise(
+                ARGON_MODEL,
                 number_of_atoms=16,
                 temperature=300,
                 box=30,
                 init_conf="metropolis",
                 seed=seed,
-                **ARGON_MODEL,
             )
             for _ in range(200):
                 a.step()
@@ -289,7 +283,7 @@ class TestMoves(unittest.TestCase):
         contribution[inside] = energy[inside] * weight[inside]
         expected = contribution.sum() / weight.sum()
         a = MCSimulation.initialise(
-            number_of_atoms=2, temperature=temperature, box=12, seed=0, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=2, temperature=temperature, box=12, seed=0
         )
         energies = []
         for _ in range(40000):
@@ -298,7 +292,7 @@ class TestMoves(unittest.TestCase):
         np.testing.assert_allclose(np.mean(energies[5000:]), expected, rtol=0.05)
 
     def test_restart_carries_the_energy_and_resets_the_counts(self):
-        a = MCSimulation.initialise(number_of_atoms=4, temperature=300, box=12, **ARGON_MODEL)
+        a = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=300, box=12)
         for _ in range(10):
             a.step()
         a.sample()

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -3,12 +3,12 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from pylj import mc
+from pylj import mc, placement
 from pylj.constants import BOLTZMANN
 from pylj.mc import MCSimulation
 from pylj.md import MDSimulation
 from pylj.pairwise import minimum_image
-from pylj.tests.argon import ARGON_MODEL, LJ_ARGON, MIXTURE_MODEL, WELL_MODEL
+from pylj.tests.argon import ARGON_MODEL, LARGER, LJ_ARGON, MIXTURE_MODEL, WELL_MODEL
 
 
 def total_energy(sim):
@@ -120,12 +120,12 @@ class TestConstructor(unittest.TestCase):
         self.assertGreater(a.accepted, 0)
         assert_equal(a.configuration.velocity, md_simulation.configuration.velocity)
 
-    def test_validates_the_temperature_before_the_model(self):
-        c = MDSimulation.initialise(
-            ARGON_MODEL, number_of_atoms=4, temperature=100, box=20
-        ).configuration
+    def test_validates_the_temperature_before_the_configuration(self):
+        # The configuration holds a species that ARGON_MODEL knows nothing
+        # about, so if the species check ran first it would raise instead.
+        c = placement.place_square(4, (LARGER,), 40e-10)
         with self.assertRaisesRegex(ValueError, "temperature must be positive"):
-            MCSimulation(c, {}, -1)
+            MCSimulation(c, ARGON_MODEL, -1)
 
 
 class TestMoves(unittest.TestCase):

--- a/pylj/tests/test_md.py
+++ b/pylj/tests/test_md.py
@@ -7,6 +7,7 @@ from pylj import md, pairwise, placement
 from pylj.configuration import MDConfiguration
 from pylj.constants import ATOMIC_MASS_UNIT, BOLTZMANN
 from pylj.md import MDSimulation
+from pylj.model import Model
 from pylj.potentials import LennardJones
 from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, MIXTURE_MODEL, WELL_MODEL
 
@@ -27,12 +28,12 @@ def two_argon(velocity, box=8e-10):
 def kinetic_plus_potential(sim):
     """The total energy of a simulation, from its configuration and stored cut-off."""
     c = sim.configuration
-    return c.kinetic_energy() + c.potential_energy(sim.pair_potentials, sim.cut_off)
+    return c.kinetic_energy() + c.potential_energy(sim.model, sim.cut_off)
 
 
 class TestInitialise(unittest.TestCase):
     def test_square_lattice_in_a_converted_box(self):
-        a = MDSimulation.initialise(number_of_atoms=2, temperature=300, box=8, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=2, temperature=300, box=8)
         c = a.configuration
         self.assertIsInstance(c, MDConfiguration)
         self.assertEqual(c.number_of_atoms, 2)
@@ -45,25 +46,25 @@ class TestInitialise(unittest.TestCase):
         self.assertEqual(a.time, 0.0)
 
     def test_forces_are_valid_after_construction(self):
-        a = MDSimulation.initialise(number_of_atoms=2, temperature=300, box=8, **ARGON_MODEL)
-        assert_allclose(a.forces, a.configuration.forces(a.pair_potentials, a.cut_off))
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=2, temperature=300, box=8)
+        assert_allclose(a.forces, a.configuration.forces(a.model, a.cut_off))
         self.assertNotEqual(a.forces[0, 1], 0.0)
 
     def test_velocities_have_no_net_momentum(self):
-        a = MDSimulation.initialise(number_of_atoms=25, temperature=100, box=40, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=25, temperature=100, box=40)
         thermal_speed = np.sqrt(BOLTZMANN * 100 / (ARGON.mass * ATOMIC_MASS_UNIT))
         momentum = a.configuration.velocity.sum(axis=0)
         self.assertLess(abs(momentum[0]), 1e-12 * thermal_speed)
         self.assertLess(abs(momentum[1]), 1e-12 * thermal_speed)
 
     def test_velocities_match_the_requested_temperature(self):
-        a = MDSimulation.initialise(number_of_atoms=25, temperature=100, box=40, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=25, temperature=100, box=40)
         assert_almost_equal(a.configuration.temperature(), 100)
 
     def test_two_species_have_no_net_momentum_at_the_temperature(self):
         # The centre-of-mass velocity is mass weighted, so with unequal
         # masses the total momentum is zero and the temperature exact.
-        a = MDSimulation.initialise(number_of_atoms=24, temperature=100, box=60, **MIXTURE_MODEL)
+        a = MDSimulation.initialise(MIXTURE_MODEL, number_of_atoms=24, temperature=100, box=60)
         c = a.configuration
         assert_allclose(c.masses[:4], np.array([39.948, 80.0, 39.948, 80.0]) * ATOMIC_MASS_UNIT)
         momentum_scale = ARGON.mass * np.sqrt(BOLTZMANN * 100 / (ARGON.mass * ATOMIC_MASS_UNIT))
@@ -78,7 +79,7 @@ class TestInitialise(unittest.TestCase):
         # the heavier ones. A thousand atoms keep the sampling noise
         # to a few per cent.
         c = MDSimulation.initialise(
-            number_of_atoms=1000, temperature=100, box=320, seed=0, **MIXTURE_MODEL
+            MIXTURE_MODEL, number_of_atoms=1000, temperature=100, box=320, seed=0
         ).configuration
         for index, species in enumerate((ARGON, LARGER)):
             speeds_squared = np.sum(c.velocity[c.species_index == index] ** 2, axis=1)
@@ -87,17 +88,17 @@ class TestInitialise(unittest.TestCase):
 
     def test_refuses_a_potential_with_no_force(self):
         with self.assertRaisesRegex(ValueError, "Monte Carlo"):
-            MDSimulation.initialise(number_of_atoms=2, temperature=300, box=8, **WELL_MODEL)
+            MDSimulation.initialise(WELL_MODEL, number_of_atoms=2, temperature=300, box=8)
 
     def test_is_reproducible_with_a_seed(self):
         def build(seed):
             return MDSimulation.initialise(
+                ARGON_MODEL,
                 number_of_atoms=10,
                 temperature=100,
                 box=40,
                 init_conf="metropolis",
                 seed=seed,
-                **ARGON_MODEL,
             )
 
         first, second, other = build(3), build(3), build(4)
@@ -111,36 +112,36 @@ class TestInitialise(unittest.TestCase):
         # 50 argon in a 27 Angstrom box cannot be placed at 1 K.
         with self.assertRaisesRegex(ValueError, "Could not place"):
             MDSimulation.initialise(
+                ARGON_MODEL,
                 number_of_atoms=50,
                 temperature=100,
                 box=27,
                 init_conf="metropolis",
                 placement_temperature=1.0,
                 seed=0,
-                **ARGON_MODEL,
             )
 
     def test_passes_the_timestep_and_cut_off_through(self):
         a = MDSimulation.initialise(
-            number_of_atoms=2, temperature=300, box=40, timestep=2e-15, cut_off=10, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=2, temperature=300, box=40, timestep=2e-15, cut_off=10
         )
         assert_almost_equal(a.timestep, 2e-15)
         assert_almost_equal(a.cut_off * 1e10, 10)
 
     def test_one_atom_raises(self):
         with self.assertRaisesRegex(ValueError, "at least two atoms"):
-            MDSimulation.initialise(number_of_atoms=1, temperature=300, box=8, **ARGON_MODEL)
+            MDSimulation.initialise(ARGON_MODEL, number_of_atoms=1, temperature=300, box=8)
 
     def test_rejects_a_non_positive_or_infinite_temperature(self):
         for temperature in (0, -10, np.inf):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 MDSimulation.initialise(
-                    number_of_atoms=2, temperature=temperature, box=8, **ARGON_MODEL
+                    ARGON_MODEL, number_of_atoms=2, temperature=temperature, box=8
                 )
 
     def test_refuses_an_overlapping_lattice(self):
         with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
-            MDSimulation.initialise(number_of_atoms=16, temperature=300, box=10, **ARGON_MODEL)
+            MDSimulation.initialise(ARGON_MODEL, number_of_atoms=16, temperature=300, box=10)
 
 
 class TestConstructor(unittest.TestCase):
@@ -148,41 +149,41 @@ class TestConstructor(unittest.TestCase):
         c = placement.place_square(2, (ARGON,), 8e-10)
         self.assertNotIsInstance(c, MDConfiguration)
         with self.assertRaisesRegex(TypeError, "MDConfiguration"):
-            MDSimulation(c, ARGON_MODEL["pair_potentials"])
+            MDSimulation(c, ARGON_MODEL)
 
     def test_refuses_a_bad_timestep(self):
         c = two_argon([[3e2, 0.0], [-3e2, 0.0]])
         for bad in (0.0, -1e-14, np.nan):
             with self.assertRaisesRegex(ValueError, "timestep must be positive"):
-                MDSimulation(c, ARGON_MODEL["pair_potentials"], timestep=bad)
+                MDSimulation(c, ARGON_MODEL, timestep=bad)
 
     def test_refuses_a_diverged_configuration(self):
         with self.assertRaisesRegex(ValueError, "diverged"):
-            MDSimulation(two_argon([[np.nan, 0.0], [1.0, 0.0]]), ARGON_MODEL["pair_potentials"])
+            MDSimulation(two_argon([[np.nan, 0.0], [1.0, 0.0]]), ARGON_MODEL)
 
     def test_refuses_a_configuration_at_rest(self):
         with self.assertRaisesRegex(ValueError, "at rest"):
-            MDSimulation(two_argon(np.zeros((2, 2))), ARGON_MODEL["pair_potentials"])
+            MDSimulation(two_argon(np.zeros((2, 2))), ARGON_MODEL)
 
     def test_checks_the_model_at_the_measured_temperature(self):
         # Sigma in Angstrom is caught against the kinetic temperature of the
         # configuration given.
-        wrong = {(ARGON, ARGON): LennardJones(epsilon=1.577e-21, sigma=3.372)}
+        wrong = Model.single(ARGON, LennardJones(epsilon=1.577e-21, sigma=3.372))
         with self.assertRaisesRegex(ValueError, "at the cut-off"):
             MDSimulation(two_argon([[3e2, 0.0], [-3e2, 0.0]]), wrong)
 
     def test_takes_a_ready_configuration(self):
         c = two_argon([[3e2, 0.0], [-3e2, 0.0]])
-        a = MDSimulation(c, ARGON_MODEL["pair_potentials"], timestep=2e-15, seed=5)
+        a = MDSimulation(c, ARGON_MODEL, timestep=2e-15, seed=5)
         self.assertIs(a.configuration, c)
         self.assertIs(a.initial_configuration, c)
         assert_almost_equal(a.timestep, 2e-15)
-        assert_allclose(a.forces, c.forces(a.pair_potentials, a.cut_off))
+        assert_allclose(a.forces, c.forces(a.model, a.cut_off))
 
 
 class TestStep(unittest.TestCase):
     def test_step_advances_the_clock(self):
-        a = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
         a.step()
         a.step()
         self.assertEqual(a.steps, 2)
@@ -193,19 +194,19 @@ class TestStep(unittest.TestCase):
             def integrate(self):
                 pass
 
-        a = Frozen.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+        a = Frozen.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
         before = a.configuration
         a.step()
         self.assertIs(a.configuration, before)
         self.assertEqual(a.steps, 1)
 
     def test_integrate_replaces_the_configuration_and_the_forces(self):
-        a = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
         before, forces_before = a.configuration, a.forces
         a.integrate()
         self.assertIsNot(a.configuration, before)
         self.assertFalse(np.array_equal(a.configuration.position, before.position))
-        assert_allclose(a.forces, a.configuration.forces(a.pair_potentials, a.cut_off))
+        assert_allclose(a.forces, a.configuration.forces(a.model, a.cut_off))
         self.assertFalse(np.array_equal(a.forces, forces_before))
         self.assertEqual(a.steps, 0)
 
@@ -217,12 +218,10 @@ class TestVelocityVerlet(unittest.TestCase):
         # Angstrom box: its wrapped position comes back in and its unwrapped
         # one does not. The forces are zeroed so the motion is the drift.
         c = two_argon([[0.0, 3e4], [0.0, 3e4]])
-        moved, forces = md.velocity_verlet(
-            c, np.zeros((2, 2)), 1e-14, ARGON_MODEL["pair_potentials"], 15e-10
-        )
+        moved, forces = md.velocity_verlet(c, np.zeros((2, 2)), 1e-14, ARGON_MODEL, 15e-10)
         assert_almost_equal(moved.unwrapped * 1e10, [[2, 5], [2, 9]])
         assert_almost_equal(moved.position * 1e10, [[2, 5], [2, 1]])
-        assert_allclose(forces, moved.forces(ARGON_MODEL["pair_potentials"], 15e-10))
+        assert_allclose(forces, moved.forces(ARGON_MODEL, 15e-10))
 
     def test_matches_the_hand_computed_step(self):
         # A pair 4 Angstrom apart, inside the cut-off, one atom drifting
@@ -231,16 +230,12 @@ class TestVelocityVerlet(unittest.TestCase):
         # times dt, with the forces at the new positions evaluated afresh.
         c = two_argon([[1e3, 0.0], [0.0, 0.0]], box=40e-10)
         cut_off = 15e-10
-        forces = c.forces(ARGON_MODEL["pair_potentials"], cut_off)
-        moved, next_forces = md.velocity_verlet(
-            c, forces, 1e-14, ARGON_MODEL["pair_potentials"], cut_off
-        )
+        forces = c.forces(ARGON_MODEL, cut_off)
+        moved, next_forces = md.velocity_verlet(c, forces, 1e-14, ARGON_MODEL, cut_off)
         accelerations = forces / c.masses[:, None]
         expected_position = c.position + c.velocity * 1e-14 + 0.5 * accelerations * 1e-28
         assert_allclose(moved.position, expected_position)
-        expected_forces = c.replace(position=expected_position).forces(
-            ARGON_MODEL["pair_potentials"], cut_off
-        )
+        expected_forces = c.replace(position=expected_position).forces(ARGON_MODEL, cut_off)
         assert_allclose(next_forces, expected_forces)
         next_accelerations = expected_forces / c.masses[:, None]
         expected_velocity = c.velocity + 0.5 * (accelerations + next_accelerations) * 1e-14
@@ -269,10 +264,10 @@ class TestVelocityVerlet(unittest.TestCase):
         # for the mixture: 3.0e-3 and 7.6e-4.
         def worst_drift(model, box, timestep, steps):
             a = MDSimulation.initialise(
-                number_of_atoms=25, temperature=100, box=box, timestep=timestep, seed=0, **model
+                model, number_of_atoms=25, temperature=100, box=box, timestep=timestep, seed=0
             )
             a.cut_off = 1e-8
-            a.forces = a.configuration.forces(a.pair_potentials, a.cut_off)
+            a.forces = a.configuration.forces(a.model, a.cut_off)
             initial = kinetic_plus_potential(a)
             drift = 0.0
             for _ in range(steps):
@@ -296,9 +291,7 @@ class TestVelocityVerlet(unittest.TestCase):
             * np.sqrt(BOLTZMANN * 100 / (ARGON.mass * ATOMIC_MASS_UNIT))
         )
         for model, box in ((ARGON_MODEL, 20), (MIXTURE_MODEL, 30)):
-            a = MDSimulation.initialise(
-                number_of_atoms=25, temperature=100, box=box, seed=0, **model
-            )
+            a = MDSimulation.initialise(model, number_of_atoms=25, temperature=100, box=box, seed=0)
             for _ in range(200):
                 a.step()
             c = a.configuration
@@ -311,7 +304,7 @@ class TestVelocityVerlet(unittest.TestCase):
         # Angstrom in one step; the integrator refuses rather than continue
         # from a configuration that is no longer meaningful.
         a = MDSimulation.initialise(
-            number_of_atoms=25, temperature=100, box=20, timestep=1e-11, seed=0, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=25, temperature=100, box=20, timestep=1e-11, seed=0
         )
         with self.assertRaisesRegex(ValueError, "half the cut-off"):
             a.step()
@@ -319,7 +312,7 @@ class TestVelocityVerlet(unittest.TestCase):
 
 class TestMSD(unittest.TestCase):
     def test_is_zero_before_the_first_step(self):
-        a = MDSimulation.initialise(number_of_atoms=16, temperature=300, box=20, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=16, temperature=300, box=20)
         self.assertEqual(a.configuration.msd(a.initial_configuration), 0.0)
 
     def test_with_sparse_sampling(self):
@@ -330,7 +323,7 @@ class TestMSD(unittest.TestCase):
         # imposed drift. The oracle accumulates the minimum-image
         # displacement between consecutive steps, which is exact while a
         # atom moves less than half a box per step.
-        a = MDSimulation(two_argon([[-1e4, 0.0], [-1e4, 0.0]]), ARGON_MODEL["pair_potentials"])
+        a = MDSimulation(two_argon([[-1e4, 0.0], [-1e4, 0.0]]), ARGON_MODEL)
         box = a.configuration.box
         total = np.zeros((2, 2))
         for _ in range(60):
@@ -345,12 +338,12 @@ class TestMSD(unittest.TestCase):
 
 class TestHeatBath(unittest.TestCase):
     def test_rescales_to_the_bath_temperature(self):
-        a = MDSimulation.initialise(number_of_atoms=10, temperature=300, box=20, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=10, temperature=300, box=20)
         a.heat_bath(250.0)
         assert_almost_equal(a.configuration.temperature() / 250.0, 1.0)
 
     def test_preserves_velocity_directions_and_the_forces(self):
-        a = MDSimulation.initialise(number_of_atoms=10, temperature=300, box=20, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=10, temperature=300, box=20)
         old = a.configuration.velocity
         forces = a.forces
         a.heat_bath(250.0)
@@ -360,7 +353,7 @@ class TestHeatBath(unittest.TestCase):
 
     def test_two_calls_each_hit_their_own_target(self):
         c = MDSimulation.initialise(
-            number_of_atoms=10, temperature=300, box=20, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=10, temperature=300, box=20
         ).configuration
         c = md.heat_bath(md.heat_bath(c, 250.0), 100.0)
         assert_almost_equal(c.temperature() / 100.0, 1.0)
@@ -383,7 +376,7 @@ class TestHeatBath(unittest.TestCase):
 
 class TestSample(unittest.TestCase):
     def test_records_the_step_and_the_thermodynamics(self):
-        a = MDSimulation.initialise(number_of_atoms=2, temperature=300, box=8, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=2, temperature=300, box=8)
         for _ in range(3):
             a.step()
         a.sample()
@@ -398,21 +391,21 @@ class TestSample(unittest.TestCase):
 
     def test_measures_the_current_configuration(self):
         a = MDSimulation.initialise(
-            number_of_atoms=20, temperature=300, box=20, seed=0, **ARGON_MODEL
+            ARGON_MODEL, number_of_atoms=20, temperature=300, box=20, seed=0
         )
         for _ in range(5):
             a.step()
         a.sample()
         c = a.configuration
         temperature = c.temperature()
-        virial = c.virial(a.pair_potentials, a.cut_off)
+        virial = c.virial(a.model, a.cut_off)
         samples = a.samples
         assert_almost_equal(samples.temperature[-1], temperature)
         assert_almost_equal(
             samples.pressure[-1],
             pairwise.calculate_pressure(virial, c.box, c.kinetic_energy()),
         )
-        potential = c.potential_energy(a.pair_potentials, a.cut_off)
+        potential = c.potential_energy(a.model, a.cut_off)
         assert_almost_equal(samples.potential_energy[-1], potential)
         assert_almost_equal(samples.kinetic_energy[-1], c.kinetic_energy())
         assert_almost_equal(samples.total_energy[-1], potential + c.kinetic_energy())
@@ -426,7 +419,7 @@ class TestRestart(unittest.TestCase):
             a.sample()
 
     def test_starts_a_fresh_record_from_the_current_state(self):
-        a = MDSimulation.initialise(number_of_atoms=4, temperature=300, box=12, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=300, box=12)
         self.run_and_sample(a, 5)
         production = a.restart()
         self.assertIsNot(production, a)
@@ -449,7 +442,7 @@ class TestRestart(unittest.TestCase):
         self.assertGreater(production.samples.msd[-1], 0.0)
 
     def test_leaves_the_source_alone(self):
-        a = MDSimulation.initialise(number_of_atoms=4, temperature=300, box=12, **ARGON_MODEL)
+        a = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=300, box=12)
         self.run_and_sample(a, 3)
         source = a.configuration
         production = a.restart()

--- a/pylj/tests/test_model.py
+++ b/pylj/tests/test_model.py
@@ -73,6 +73,10 @@ class TestModel(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "'argon' is not one of the species"):
             Model((ARGON,), {("argon", "argon"): LJ_ARGON})
 
+    def test_rejects_a_string_as_a_species(self):
+        with self.assertRaisesRegex(TypeError, r"Species\(mass="):
+            Model(("argon",), {("argon", "argon"): LJ_ARGON})
+
     def test_is_frozen(self):
         model = Model.single(ARGON, LJ_ARGON)
         with self.assertRaises(AttributeError):
@@ -97,4 +101,4 @@ class TestModel(unittest.TestCase):
     def test_repr_names_the_species_and_potentials(self):
         text = repr(Model.single(ARGON, LJ_ARGON))
         self.assertTrue(text.startswith("Model(species=("))
-        self.assertIn("LennardJones", text)
+        self.assertIn("LennardJones(epsilon=", text)

--- a/pylj/tests/test_model.py
+++ b/pylj/tests/test_model.py
@@ -2,7 +2,7 @@ import unittest
 
 from pylj.model import Model
 from pylj.potentials import LennardJones, Species
-from pylj.tests.argon import ARGON, LARGER, LJ_ARGON, LJ_ARGON_LARGER, LJ_LARGER
+from pylj.tests.argon import ARGON, LARGER, LJ_ARGON, LJ_ARGON_LARGER, LJ_LARGER, MIXTURE_MODEL
 
 
 class TestModel(unittest.TestCase):
@@ -12,21 +12,13 @@ class TestModel(unittest.TestCase):
         self.assertEqual(model.pair_potentials, {(ARGON, ARGON): LJ_ARGON})
 
     def test_potential_is_found_in_either_order(self):
-        model = Model(
-            (ARGON, LARGER),
-            {
-                (ARGON, ARGON): LJ_ARGON,
-                (LARGER, LARGER): LJ_LARGER,
-                (LARGER, ARGON): LJ_ARGON_LARGER,
-            },
-        )
-        self.assertIs(model.potential(ARGON, LARGER), LJ_ARGON_LARGER)
-        self.assertIs(model.potential(LARGER, ARGON), LJ_ARGON_LARGER)
+        self.assertIs(MIXTURE_MODEL.potential(ARGON, LARGER), LJ_ARGON_LARGER)
+        self.assertIs(MIXTURE_MODEL.potential(LARGER, ARGON), LJ_ARGON_LARGER)
 
-    def test_potential_names_a_species_outside_the_model(self):
-        model = Model.single(ARGON, LJ_ARGON)
-        with self.assertRaisesRegex(KeyError, "larger.*is not a species"):
-            model.potential(ARGON, LARGER)
+    def test_potential_shows_the_species_that_differs(self):
+        twin = Species(mass=40.0, name="argon")
+        with self.assertRaisesRegex(KeyError, "mass=40.0"):
+            Model.single(ARGON, LJ_ARGON).potential(twin, twin)
 
     def test_rejects_a_missing_pair(self):
         with self.assertRaisesRegex(ValueError, "no entry for the pair .*larger"):
@@ -61,37 +53,29 @@ class TestModel(unittest.TestCase):
         model = Model([ARGON], {(ARGON, ARGON): LJ_ARGON})
         self.assertEqual(model.species, (ARGON,))
 
-    def test_names_single_for_a_bare_species(self):
+    def test_names_single_for_an_argument_that_is_not_a_sequence_or_mapping(self):
         with self.assertRaisesRegex(TypeError, "Model.single"):
             Model(ARGON, {(ARGON, ARGON): LJ_ARGON})
-
-    def test_names_single_for_a_bare_potential(self):
-        with self.assertRaisesRegex(TypeError, "Model.single"):
-            Model((ARGON,), LJ_ARGON)
-
-    def test_rejects_a_string_as_the_species_sequence(self):
         with self.assertRaisesRegex(TypeError, "Model.single"):
             Model("argon", {(ARGON, ARGON): LJ_ARGON})
-
-    def test_rejects_a_bare_species_as_a_key(self):
-        with self.assertRaisesRegex(ValueError, "must be a pair of species"):
-            Model((ARGON,), {ARGON: LJ_ARGON})
-
-    def test_rejects_a_key_that_is_not_a_pair(self):
-        with self.assertRaisesRegex(ValueError, "must be a pair of species"):
-            Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, ARGON, ARGON): LJ_ARGON})
-
-    def test_rejects_an_entry_for_a_species_outside_the_model(self):
-        with self.assertRaisesRegex(ValueError, "not one of the species"):
-            Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, LARGER): LJ_ARGON_LARGER})
-
-    def test_rejects_a_string_in_place_of_a_species(self):
-        with self.assertRaisesRegex(ValueError, "'argon' is not one of the species"):
-            Model((ARGON,), {("argon", "argon"): LJ_ARGON})
+        with self.assertRaisesRegex(TypeError, "Model.single"):
+            Model((ARGON,), LJ_ARGON)
 
     def test_rejects_a_string_as_a_species(self):
         with self.assertRaisesRegex(TypeError, r"Species\(mass="):
             Model(("argon",), {("argon", "argon"): LJ_ARGON})
+
+    def test_rejects_a_key_that_is_not_a_pair(self):
+        with self.assertRaisesRegex(ValueError, "must be a pair of species"):
+            Model((ARGON,), {ARGON: LJ_ARGON})
+        with self.assertRaisesRegex(ValueError, "must be a pair of species"):
+            Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, ARGON, ARGON): LJ_ARGON})
+
+    def test_rejects_an_entry_naming_something_outside_the_species(self):
+        with self.assertRaisesRegex(ValueError, "not one of the species"):
+            Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, LARGER): LJ_ARGON_LARGER})
+        with self.assertRaisesRegex(ValueError, "'argon' is not one of the species"):
+            Model((ARGON,), {("argon", "argon"): LJ_ARGON})
 
     def test_is_frozen(self):
         model = Model.single(ARGON, LJ_ARGON)
@@ -108,11 +92,6 @@ class TestModel(unittest.TestCase):
         model = Model.single(ARGON, LJ_ARGON)
         with self.assertRaises(TypeError):
             model.pair_potentials[(ARGON, ARGON)] = LJ_LARGER
-
-    def test_potential_shows_the_species_that_differs(self):
-        twin = Species(mass=40.0, name="argon")
-        with self.assertRaisesRegex(KeyError, "mass=40.0"):
-            Model.single(ARGON, LJ_ARGON).potential(twin, twin)
 
     def test_repr_names_the_species_and_potentials(self):
         text = repr(Model.single(ARGON, LJ_ARGON))

--- a/pylj/tests/test_model.py
+++ b/pylj/tests/test_model.py
@@ -1,7 +1,7 @@
 import unittest
 
 from pylj.model import Model
-from pylj.potentials import LennardJones
+from pylj.potentials import LennardJones, Species
 from pylj.tests.argon import ARGON, LARGER, LJ_ARGON, LJ_ARGON_LARGER, LJ_LARGER
 
 
@@ -23,9 +23,9 @@ class TestModel(unittest.TestCase):
         self.assertIs(model.potential(ARGON, LARGER), LJ_ARGON_LARGER)
         self.assertIs(model.potential(LARGER, ARGON), LJ_ARGON_LARGER)
 
-    def test_potential_names_a_pair_outside_the_model(self):
+    def test_potential_names_a_species_outside_the_model(self):
         model = Model.single(ARGON, LJ_ARGON)
-        with self.assertRaisesRegex(KeyError, "argon and larger"):
+        with self.assertRaisesRegex(KeyError, "larger is not a species"):
             model.potential(ARGON, LARGER)
 
     def test_rejects_a_missing_pair(self):
@@ -52,7 +52,18 @@ class TestModel(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "at least one Species"):
             Model((), {})
 
+    def test_rejects_a_repeated_species(self):
+        twin = Species(mass=ARGON.mass, name=ARGON.name)
+        with self.assertRaisesRegex(ValueError, "must not repeat"):
+            Model((ARGON, twin), {(ARGON, ARGON): LJ_ARGON})
+
     def test_is_frozen(self):
         model = Model.single(ARGON, LJ_ARGON)
         with self.assertRaises(AttributeError):
             model.species = ()
+
+    def test_copies_the_pair_potentials(self):
+        pair_potentials = {(ARGON, ARGON): LJ_ARGON}
+        model = Model((ARGON,), pair_potentials)
+        pair_potentials[(ARGON, ARGON)] = LJ_LARGER
+        self.assertIs(model.potential(ARGON, ARGON), LJ_ARGON)

--- a/pylj/tests/test_model.py
+++ b/pylj/tests/test_model.py
@@ -25,7 +25,7 @@ class TestModel(unittest.TestCase):
 
     def test_potential_names_a_species_outside_the_model(self):
         model = Model.single(ARGON, LJ_ARGON)
-        with self.assertRaisesRegex(KeyError, "larger is not a species"):
+        with self.assertRaisesRegex(KeyError, "larger.*is not a species"):
             model.potential(ARGON, LARGER)
 
     def test_rejects_a_missing_pair(self):
@@ -57,6 +57,22 @@ class TestModel(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must not repeat"):
             Model((ARGON, twin), {(ARGON, ARGON): LJ_ARGON})
 
+    def test_accepts_any_sequence_of_species(self):
+        model = Model([ARGON], {(ARGON, ARGON): LJ_ARGON})
+        self.assertEqual(model.species, (ARGON,))
+
+    def test_names_single_for_a_bare_species(self):
+        with self.assertRaisesRegex(TypeError, "Model.single"):
+            Model(ARGON, {(ARGON, ARGON): LJ_ARGON})
+
+    def test_rejects_an_entry_for_a_species_outside_the_model(self):
+        with self.assertRaisesRegex(ValueError, "not one of the species"):
+            Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, LARGER): LJ_ARGON_LARGER})
+
+    def test_rejects_a_string_in_place_of_a_species(self):
+        with self.assertRaisesRegex(ValueError, "'argon' is not one of the species"):
+            Model((ARGON,), {("argon", "argon"): LJ_ARGON})
+
     def test_is_frozen(self):
         model = Model.single(ARGON, LJ_ARGON)
         with self.assertRaises(AttributeError):
@@ -67,3 +83,18 @@ class TestModel(unittest.TestCase):
         model = Model((ARGON,), pair_potentials)
         pair_potentials[(ARGON, ARGON)] = LJ_LARGER
         self.assertIs(model.potential(ARGON, ARGON), LJ_ARGON)
+
+    def test_pair_potentials_are_read_only(self):
+        model = Model.single(ARGON, LJ_ARGON)
+        with self.assertRaises(TypeError):
+            model.pair_potentials[(ARGON, ARGON)] = LJ_LARGER
+
+    def test_potential_shows_the_species_that_differs(self):
+        twin = Species(mass=40.0, name="argon")
+        with self.assertRaisesRegex(KeyError, "mass=40.0"):
+            Model.single(ARGON, LJ_ARGON).potential(twin, twin)
+
+    def test_repr_names_the_species_and_potentials(self):
+        text = repr(Model.single(ARGON, LJ_ARGON))
+        self.assertTrue(text.startswith("Model(species=("))
+        self.assertIn("LennardJones", text)

--- a/pylj/tests/test_model.py
+++ b/pylj/tests/test_model.py
@@ -1,0 +1,58 @@
+import unittest
+
+from pylj.model import Model
+from pylj.potentials import LennardJones
+from pylj.tests.argon import ARGON, LARGER, LJ_ARGON, LJ_ARGON_LARGER, LJ_LARGER
+
+
+class TestModel(unittest.TestCase):
+    def test_single_builds_one_species_and_its_own_pair(self):
+        model = Model.single(ARGON, LJ_ARGON)
+        self.assertEqual(model.species, (ARGON,))
+        self.assertEqual(model.pair_potentials, {(ARGON, ARGON): LJ_ARGON})
+
+    def test_potential_is_found_in_either_order(self):
+        model = Model(
+            (ARGON, LARGER),
+            {
+                (ARGON, ARGON): LJ_ARGON,
+                (LARGER, LARGER): LJ_LARGER,
+                (LARGER, ARGON): LJ_ARGON_LARGER,
+            },
+        )
+        self.assertIs(model.potential(ARGON, LARGER), LJ_ARGON_LARGER)
+        self.assertIs(model.potential(LARGER, ARGON), LJ_ARGON_LARGER)
+
+    def test_potential_names_a_pair_outside_the_model(self):
+        model = Model.single(ARGON, LJ_ARGON)
+        with self.assertRaisesRegex(KeyError, "argon and larger"):
+            model.potential(ARGON, LARGER)
+
+    def test_rejects_a_missing_pair(self):
+        with self.assertRaisesRegex(ValueError, "no entry for the pair .*larger"):
+            Model((ARGON, LARGER), {(ARGON, ARGON): LJ_ARGON, (LARGER, LARGER): LJ_LARGER})
+
+    def test_rejects_a_cross_pair_given_in_both_orders(self):
+        with self.assertRaisesRegex(ValueError, "in both orders"):
+            Model(
+                (ARGON, LARGER),
+                {
+                    (ARGON, ARGON): LJ_ARGON,
+                    (LARGER, LARGER): LJ_LARGER,
+                    (ARGON, LARGER): LJ_ARGON_LARGER,
+                    (LARGER, ARGON): LJ_ARGON_LARGER,
+                },
+            )
+
+    def test_rejects_a_potential_class_in_place_of_an_instance(self):
+        with self.assertRaisesRegex(TypeError, "PairPotential instance"):
+            Model((ARGON,), {(ARGON, ARGON): LennardJones})
+
+    def test_rejects_no_species(self):
+        with self.assertRaisesRegex(ValueError, "at least one Species"):
+            Model((), {})
+
+    def test_is_frozen(self):
+        model = Model.single(ARGON, LJ_ARGON)
+        with self.assertRaises(AttributeError):
+            model.species = ()

--- a/pylj/tests/test_model.py
+++ b/pylj/tests/test_model.py
@@ -65,6 +65,22 @@ class TestModel(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "Model.single"):
             Model(ARGON, {(ARGON, ARGON): LJ_ARGON})
 
+    def test_names_single_for_a_bare_potential(self):
+        with self.assertRaisesRegex(TypeError, "Model.single"):
+            Model((ARGON,), LJ_ARGON)
+
+    def test_rejects_a_string_as_the_species_sequence(self):
+        with self.assertRaisesRegex(TypeError, "Model.single"):
+            Model("argon", {(ARGON, ARGON): LJ_ARGON})
+
+    def test_rejects_a_bare_species_as_a_key(self):
+        with self.assertRaisesRegex(ValueError, "must be a pair of species"):
+            Model((ARGON,), {ARGON: LJ_ARGON})
+
+    def test_rejects_a_key_that_is_not_a_pair(self):
+        with self.assertRaisesRegex(ValueError, "must be a pair of species"):
+            Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, ARGON, ARGON): LJ_ARGON})
+
     def test_rejects_an_entry_for_a_species_outside_the_model(self):
         with self.assertRaisesRegex(ValueError, "not one of the species"):
             Model((ARGON,), {(ARGON, ARGON): LJ_ARGON, (ARGON, LARGER): LJ_ARGON_LARGER})

--- a/pylj/tests/test_pairwise.py
+++ b/pylj/tests/test_pairwise.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import pairwise
-from pylj.tests.argon import ARGON, LARGER, LJ_ARGON_LARGER
 
 
 class TestPairwise(unittest.TestCase):
@@ -25,11 +24,6 @@ class TestPairwise(unittest.TestCase):
         assert_almost_equal(
             pairwise.minimum_image(separation, 10e-10) * 1e10, [[-1.0, 4.0], [4.0, 0.0]]
         )
-
-    def test_pair_potential_is_found_in_either_key_order(self):
-        pair_potentials = {(LARGER, ARGON): LJ_ARGON_LARGER}
-        self.assertIs(pairwise.pair_potential(pair_potentials, ARGON, LARGER), LJ_ARGON_LARGER)
-        self.assertIs(pairwise.pair_potential(pair_potentials, LARGER, ARGON), LJ_ARGON_LARGER)
 
     def test_species_pairs_yields_each_unordered_pair_once(self):
         # Atoms of species 0, 1, 0: pairs (0, 1), (0, 2), (1, 2) are

--- a/pylj/tests/test_placement.py
+++ b/pylj/tests/test_placement.py
@@ -169,12 +169,6 @@ class TestPlace(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 place(2, temperature, 8)
 
-    def test_accepts_a_pair_potential_keyed_in_either_order(self):
-        reversed_cross = dict(MIXTURE_MODEL.pair_potentials)
-        reversed_cross[(LARGER, ARGON)] = reversed_cross.pop((ARGON, LARGER))
-        c, _ = place(2, 300, 12, model=Model((ARGON, LARGER), reversed_cross))
-        assert_equal(c.species_index, [0, 1])
-
     def test_refuses_a_potential_still_repulsive_at_the_cut_off(self):
         # Sigma given in Angstrom: the pair energy is astronomically positive
         # at the cut-off, where a sensible potential has died away.

--- a/pylj/tests/test_placement.py
+++ b/pylj/tests/test_placement.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import pairwise, placement
 from pylj.constants import ATOMIC_MASS_UNIT
+from pylj.model import Model
 from pylj.potentials import LennardJones, SquareWell
 from pylj.tests.argon import (
     ARGON,
@@ -30,20 +31,17 @@ def place(
     cut_off=None,
     seed=None,
     model=ARGON_MODEL,
-    **overrides,
 ):
     """placement.place with the argon model and a seeded generator."""
-    kwargs = dict(model)
-    kwargs.update(overrides)
     return placement.place(
         n,
         temperature,
         box,
+        model=model,
         init_conf=init_conf,
         placement_temperature=placement_temperature,
         cut_off=cut_off,
         rng=np.random.default_rng(seed),
-        **kwargs,
     )
 
 
@@ -70,18 +68,17 @@ class TestPlacement(unittest.TestCase):
         # A trial inside the square well's core costs infinite energy and is
         # always rejected, so no pair is closer than sigma.
         c, cut_off = place(50, 300, 30, init_conf="metropolis", seed=1, model=WELL_MODEL)
-        distance = c.pairs(WELL_MODEL["pair_potentials"], cut_off).distance
+        distance = c.pairs(WELL_MODEL, cut_off).distance
         self.assertGreaterEqual(distance.min(), WELL.sigma)
 
     def test_metropolis_places_a_mixture_with_each_pairs_own_potential(self):
         # Hard cores of three different diameters: no pair may sit inside the
         # core of its own potential. A placement using the wrong potential
         # for a pair lets it inside the true core.
-        potentials = WELL_MIXTURE_MODEL["pair_potentials"]
         c, cut_off = place(30, 300, 40, init_conf="metropolis", seed=0, model=WELL_MIXTURE_MODEL)
-        distance = c.pairs(potentials, cut_off).distance
+        distance = c.pairs(WELL_MIXTURE_MODEL, cut_off).distance
         for mask, type_1, type_2 in pairwise.species_pairs(c.species_index):
-            potential = pairwise.pair_potential(potentials, c.species[type_1], c.species[type_2])
+            potential = WELL_MIXTURE_MODEL.potential(c.species[type_1], c.species[type_2])
             core = potential.sigma
             self.assertGreaterEqual(distance[mask].min(), core)
 
@@ -90,7 +87,7 @@ class TestPlacement(unittest.TestCase):
         # so a trial there would be accepted as downhill; the potential's
         # min_separation makes such a trial cost infinite energy instead.
         c, cut_off = place(30, 300, 40, init_conf="metropolis", seed=0, model=BUCKINGHAM_MODEL)
-        pairs = c.pairs(BUCKINGHAM_MODEL["pair_potentials"], cut_off)
+        pairs = c.pairs(BUCKINGHAM_MODEL, cut_off)
         self.assertGreater(pairs.distance.min(), BUCKINGHAM_ARGON.min_separation)
         self.assertTrue(np.isfinite(pairs.energy).all())
 
@@ -98,7 +95,7 @@ class TestPlacement(unittest.TestCase):
         # Lennard-Jones has no hard core, but at 100 K a pair inside 0.8
         # sigma costs over 40 well depths and is never accepted.
         c, cut_off = place(30, 100, 40, init_conf="metropolis", seed=0)
-        distance = c.pairs(ARGON_MODEL["pair_potentials"], cut_off).distance
+        distance = c.pairs(ARGON_MODEL, cut_off).distance
         self.assertGreater(distance.min(), 0.8 * LJ_ARGON.sigma)
 
     def test_metropolis_too_dense_raises(self):
@@ -172,56 +169,37 @@ class TestPlace(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "temperature must be positive"):
                 place(2, temperature, 8)
 
-    def test_rejects_a_missing_pair_potential(self):
-        incomplete = {(ARGON, ARGON): LJ_ARGON, (LARGER, LARGER): LJ_ARGON}
-        with self.assertRaisesRegex(ValueError, "no entry for the pair .*larger"):
-            place(2, 300, 12, species=[ARGON, LARGER], pair_potentials=incomplete)
-
     def test_accepts_a_pair_potential_keyed_in_either_order(self):
-        reversed_cross = dict(MIXTURE_MODEL["pair_potentials"])
+        reversed_cross = dict(MIXTURE_MODEL.pair_potentials)
         reversed_cross[(LARGER, ARGON)] = reversed_cross.pop((ARGON, LARGER))
-        c, _ = place(2, 300, 12, species=[ARGON, LARGER], pair_potentials=reversed_cross)
+        c, _ = place(2, 300, 12, model=Model((ARGON, LARGER), reversed_cross))
         assert_equal(c.species_index, [0, 1])
-
-    def test_rejects_a_potential_class_in_place_of_an_instance(self):
-        with self.assertRaisesRegex(TypeError, "PairPotential instance"):
-            place(2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): LennardJones})
-
-    def test_rejects_a_cross_pair_given_in_both_orders(self):
-        both_orders = dict(MIXTURE_MODEL["pair_potentials"])
-        both_orders[(LARGER, ARGON)] = LJ_ARGON
-        with self.assertRaisesRegex(ValueError, "in both orders"):
-            place(2, 300, 12, species=[ARGON, LARGER], pair_potentials=both_orders)
-
-    def test_rejects_no_species(self):
-        with self.assertRaisesRegex(ValueError, "at least one Species"):
-            place(2, 300, 8, species=[], pair_potentials={})
 
     def test_refuses_a_potential_still_repulsive_at_the_cut_off(self):
         # Sigma given in Angstrom: the pair energy is astronomically positive
         # at the cut-off, where a sensible potential has died away.
         in_angstrom = LennardJones(epsilon=1.577e-21, sigma=3.372)
         with self.assertRaisesRegex(ValueError, "at the cut-off"):
-            place(2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom})
+            place(2, 300, 8, model=Model.single(ARGON, in_angstrom))
 
     def test_refuses_a_potential_still_attractive_at_the_cut_off(self):
         # Epsilon typed in kJ/mol: a well about 1e17 k_B T deep at the cut-off.
         deep = LennardJones(epsilon=0.95, sigma=3.372e-10)
         with self.assertRaisesRegex(ValueError, "at the cut-off"):
-            place(2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): deep})
+            place(2, 300, 8, model=Model.single(ARGON, deep))
 
     def test_refuses_a_hard_core_wider_than_the_cut_off(self):
         wide = SquareWell(epsilon=1.5e-21, sigma=8e-10, lambda_=1.5)
         with self.assertRaisesRegex(ValueError, "hard core is wider than the cut-off"):
-            place(2, 300, 10, species=[ARGON], pair_potentials={(ARGON, ARGON): wide})
+            place(2, 300, 10, model=Model.single(ARGON, wide))
 
     def test_refuses_a_cross_potential_still_repulsive_at_the_cut_off(self):
-        mistyped = dict(MIXTURE_MODEL["pair_potentials"])
+        mistyped = dict(MIXTURE_MODEL.pair_potentials)
         mistyped[(ARGON, LARGER)] = LennardJones(epsilon=1.577e-21, sigma=4.186)
         with self.assertRaisesRegex(ValueError, "between argon and larger"):
-            place(4, 100, 60, species=MIXTURE_MODEL["species"], pair_potentials=mistyped)
+            place(4, 100, 60, model=Model(MIXTURE_MODEL.species, mistyped))
 
     def test_names_half_the_box_when_the_cut_off_came_from_it(self):
         in_angstrom = LennardJones(epsilon=1.577e-21, sigma=3.372)
         with self.assertRaisesRegex(ValueError, r"\(half the box\).*Use a larger box"):
-            place(2, 300, 8, species=[ARGON], pair_potentials={(ARGON, ARGON): in_angstrom})
+            place(2, 300, 8, model=Model.single(ARGON, in_angstrom))

--- a/pylj/tests/test_potentials.py
+++ b/pylj/tests/test_potentials.py
@@ -91,6 +91,10 @@ class TestLennardJones:
         assert lj.energies(np.array([0.0]))[0] == np.inf
         assert lj.forces(np.array([0.0]))[0] == np.inf
 
+    def test_repr_is_the_constructor_call(self):
+        lj = LennardJones(epsilon=1.577e-21, sigma=3.372e-10)
+        assert repr(lj) == "LennardJones(epsilon=1.577e-21, sigma=3.372e-10)"
+
 
 class TestBuckingham:
     def test_constructor_is_keyword_only(self):
@@ -152,6 +156,10 @@ class TestBuckingham:
         assert bk.min_separation == 0.0
         assert np.isfinite(bk.energies(np.array([1e-12]))[0])
 
+    def test_repr_is_the_constructor_call(self):
+        bk = Buckingham(a=1e-16, b=3e10, c=1e-77)
+        assert repr(bk) == "Buckingham(a=1e-16, b=30000000000.0, c=1e-77)"
+
     def test_other_potentials_are_physical_everywhere(self):
         assert LennardJones(epsilon=1.65e-21, sigma=3.4e-10).min_separation == 0.0
         assert SquareWell(epsilon=1.65e-21, sigma=3.4e-10, lambda_=1.5).min_separation == 0.0
@@ -193,3 +201,9 @@ class TestSquareWell:
         sw = SquareWell(epsilon=1.65e-21, sigma=3.4e-10, lambda_=1.5)
         with pytest.raises(ValueError, match="Monte Carlo"):
             sw.forces(np.array([4.0e-10]))
+
+    def test_repr_is_the_constructor_call(self):
+        sw = SquareWell(epsilon=1.65e-21, sigma=3.4e-10, lambda_=1.5, max_val=1e-19)
+        assert repr(sw) == (
+            "SquareWell(epsilon=1.65e-21, sigma=3.4e-10, lambda_=1.5, max_val=1e-19)"
+        )

--- a/pylj/tests/test_potentials.py
+++ b/pylj/tests/test_potentials.py
@@ -207,3 +207,8 @@ class TestSquareWell:
         assert repr(sw) == (
             "SquareWell(epsilon=1.65e-21, sigma=3.4e-10, lambda_=1.5, max_val=1e-19)"
         )
+
+    def test_repr_omits_the_default_max_val(self):
+        sw = SquareWell(epsilon=1.65e-21, sigma=3.4e-10, lambda_=1.5)
+        assert repr(sw).endswith("lambda_=1.5)")
+        assert "max_val" not in repr(sw)

--- a/pylj/tests/test_sample.py
+++ b/pylj/tests/test_sample.py
@@ -11,6 +11,7 @@ from pylj import pairwise
 from pylj.configuration import Configuration
 from pylj.mc import MCSimulation
 from pylj.md import MDSimulation
+from pylj.model import Model
 from pylj.potentials import PairPotential
 from pylj.sample import (
     RDF,
@@ -60,7 +61,7 @@ def run_md_loop(simulation, steps: int, every: int):
 def sampled_md_simulation(steps: int, every: int):
     """Initialise a fresh MD simulation and run it, sampling every ``every``-th step."""
     return run_md_loop(
-        MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL),
+        MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20),
         steps,
         every,
     )
@@ -69,7 +70,7 @@ def sampled_md_simulation(steps: int, every: int):
 def sampled_mc_simulation(steps: int):
     """Run an MC loop that samples once per step, starting at step 0."""
     simulation = MCSimulation.initialise(
-        number_of_atoms=4, temperature=100, box=20, seed=0, **ARGON_MODEL
+        ARGON_MODEL, number_of_atoms=4, temperature=100, box=20, seed=0
     )
     simulation.sample()
     for _ in range(steps):
@@ -128,9 +129,7 @@ def test_fit_axes_is_silent_on_empty_data():
 
 
 def test_cell_pane_draws_each_type_separately():
-    simulation = MDSimulation.initialise(
-        number_of_atoms=4, temperature=100, box=30, **MIXTURE_MODEL
-    )
+    simulation = MDSimulation.initialise(MIXTURE_MODEL, number_of_atoms=4, temperature=100, box=30)
     fig, ax = environment(1)
     pane = CellPane()
     pane.setup(ax, simulation)
@@ -147,7 +146,7 @@ def test_cell_pane_draws_periodic_images_of_atoms_at_the_edges():
     # the corner is drawn four times; one in the middle once.
     position = np.array([[0.5e-10, 10e-10], [0.5e-10, 0.5e-10], [10e-10, 10e-10]])
     configuration = Configuration(position, (ARGON,), np.zeros(3, dtype=np.int64), 20e-10)
-    simulation = MCSimulation(configuration, ARGON_MODEL["pair_potentials"], 100)
+    simulation = MCSimulation(configuration, ARGON_MODEL, 100)
     fig, ax = environment(1)
     pane = CellPane(diameter=4.0)
     pane.setup(ax, simulation)
@@ -171,7 +170,7 @@ def test_cell_pane_draws_periodic_images_of_atoms_at_the_edges():
 @pytest.mark.parametrize("box_length", [20, 40])
 def test_cell_pane_marker_matches_the_drawn_diameter(box_length):
     simulation = MDSimulation.initialise(
-        number_of_atoms=4, temperature=100, box=box_length, **ARGON_MODEL
+        ARGON_MODEL, number_of_atoms=4, temperature=100, box=box_length
     )
     fig, ax = environment(1)
     pane = CellPane(diameter=4.0)
@@ -192,7 +191,7 @@ def test_cell_pane_marker_matches_the_drawn_diameter(box_length):
 
 def test_cell_pane_default_diameter_is_the_potential_minimum():
     # For Lennard-Jones the energy minimum is at 2^(1/6) sigma.
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = CellPane()
     pane.setup(ax, simulation)
@@ -201,9 +200,7 @@ def test_cell_pane_default_diameter_is_the_potential_minimum():
 
 
 def test_cell_pane_default_diameter_is_per_species():
-    simulation = MDSimulation.initialise(
-        number_of_atoms=4, temperature=100, box=30, **MIXTURE_MODEL
-    )
+    simulation = MDSimulation.initialise(MIXTURE_MODEL, number_of_atoms=4, temperature=100, box=30)
     fig, ax = environment(1)
     pane = CellPane()
     pane.setup(ax, simulation)
@@ -212,9 +209,7 @@ def test_cell_pane_default_diameter_is_per_species():
 
 
 def test_cell_pane_takes_one_diameter_per_species():
-    simulation = MDSimulation.initialise(
-        number_of_atoms=4, temperature=100, box=30, **MIXTURE_MODEL
-    )
+    simulation = MDSimulation.initialise(MIXTURE_MODEL, number_of_atoms=4, temperature=100, box=30)
     fig, ax = environment(1)
     pane = CellPane(diameter=[3.0, 5.0])
     pane.setup(ax, simulation)
@@ -225,7 +220,7 @@ def test_cell_pane_takes_one_diameter_per_species():
 def test_cell_pane_default_diameter_for_a_square_well_is_the_hard_core():
     # The square-well energy steps from an infinite core through the well to
     # zero, so the default drawn diameter is the hard-core diameter sigma.
-    simulation = MCSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **WELL_MODEL)
+    simulation = MCSimulation.initialise(WELL_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = CellPane()
     pane.setup(ax, simulation)
@@ -243,9 +238,7 @@ def test_cell_pane_default_diameter_for_a_square_well_is_the_hard_core():
     ],
 )
 def test_cell_pane_rejects_a_bad_diameter(diameter, message):
-    simulation = MDSimulation.initialise(
-        number_of_atoms=4, temperature=100, box=30, **MIXTURE_MODEL
-    )
+    simulation = MDSimulation.initialise(MIXTURE_MODEL, number_of_atoms=4, temperature=100, box=30)
     fig, ax = environment(1)
     with pytest.raises(ValueError, match=message):
         CellPane(diameter=diameter).setup(ax, simulation)
@@ -265,8 +258,8 @@ def test_cell_pane_default_needs_a_potential_minimum():
             dr = np.asarray(dr, dtype=float)
             return 1e-21 * (12 * (3e-10 / dr) ** 12 / dr + 1e-3 / 3e-10)
 
-    model = {"species": [ARGON], "pair_potentials": {(ARGON, ARGON): Unbounded()}}
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **model)
+    model = Model.single(ARGON, Unbounded())
+    simulation = MDSimulation.initialise(model, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     with pytest.raises(ValueError, match="no minimum"):
         CellPane().setup(ax, simulation)
@@ -278,7 +271,7 @@ def test_cell_pane_default_needs_a_potential_minimum():
 
 def test_named_viewers_take_a_diameter(drawing_display):
     viewer = JustCell(
-        MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL),
+        MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20),
         diameter=4.0,
     )
     assert_allclose(viewer.panes[0].diameters, [4e-10])
@@ -286,7 +279,7 @@ def test_named_viewers_take_a_diameter(drawing_display):
 
 @pytest.mark.parametrize("pane_cls", list(SERIES_PANES) + [EnergyPane])
 def test_time_panes_handle_empty_and_sparse_samples(pane_cls):
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = pane_cls()
     pane.setup(ax, simulation)
@@ -314,7 +307,7 @@ def test_energy_pane_md_plots_the_total_energy():
     pane.setup(ax, simulation)
     pane.update(ax, simulation)
     c = simulation.configuration
-    potential = c.potential_energy(simulation.pair_potentials, simulation.cut_off)
+    potential = c.potential_energy(simulation.model, simulation.cut_off)
     assert_allclose(ax.lines[0].get_ydata()[-1], potential + c.kinetic_energy())
     assert_allclose(ax.lines[0].get_ydata(), simulation.samples.total_energy)
     assert_allclose(ax.lines[0].get_xdata(), simulation.samples.step * simulation.timestep * 1e12)
@@ -333,7 +326,7 @@ def test_energy_pane_refuses_a_simulation_that_records_no_energy():
         def sample(self):
             self.samples.add(step=self.steps)
 
-    bare = Bare(place_square(4, (ARGON,), 20e-10), ARGON_MODEL["pair_potentials"])
+    bare = Bare(place_square(4, (ARGON,), 20e-10), ARGON_MODEL)
     fig, ax = environment(1)
     pane = EnergyPane()
     pane.setup(ax, bare)
@@ -356,7 +349,7 @@ def test_energy_pane_mc_plots_against_step():
 
 def test_rdf_pane_normalisation_is_unity_for_metropolis_positions():
     simulation = MDSimulation.initialise(
-        number_of_atoms=400, temperature=100, box=100, init_conf="metropolis", seed=1, **ARGON_MODEL
+        ARGON_MODEL, number_of_atoms=400, temperature=100, box=100, init_conf="metropolis", seed=1
     )
     fig, ax = environment(1)
     pane = RDFPane()
@@ -383,7 +376,7 @@ def test_rdf_pane_average_is_mean_of_updates():
 
 
 def test_rdf_pane_x_values_are_the_bin_centres():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = RDFPane()
     pane.setup(ax, simulation)
@@ -397,7 +390,7 @@ def test_rdf_pane_x_values_are_the_bin_centres():
 
 
 def test_rdf_pane_axes_are_in_angstrom_with_visible_y_ticks():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = RDFPane()
     pane.setup(ax, simulation)
@@ -437,7 +430,7 @@ def test_scattering_pane_is_finite_and_non_negative():
 
 
 def test_scattering_pane_matches_direct_debye_sum():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = ScatteringPane()
     pane.setup(ax, simulation)
@@ -455,7 +448,7 @@ def test_scattering_pane_matches_direct_debye_sum():
 
 
 def test_maxwell_boltzmann_pane_accumulates_speeds():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = MaxwellBoltzmannPane()
     pane.setup(ax, simulation)
@@ -477,7 +470,7 @@ def test_maxwell_boltzmann_pane_accumulates_speeds():
 
 
 def test_maxwell_boltzmann_pane_draws_a_post_step_histogram():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     with_velocity(simulation, 100.0, 0.0)
     fig, ax = environment(1)
     pane = MaxwellBoltzmannPane()
@@ -491,7 +484,7 @@ def test_maxwell_boltzmann_pane_draws_a_post_step_histogram():
 
 
 def test_custom_pane_plots_supplied_data():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = CustomPane("x label", "y label")
     pane.setup(ax, simulation)
@@ -509,7 +502,7 @@ def test_custom_pane_rejects_mismatched_data():
 
 
 def test_custom_pane_takes_scalar_data():
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     fig, ax = environment(1)
     pane = CustomPane("x label", "y label")
     pane.setup(ax, simulation)
@@ -529,14 +522,14 @@ def test_custom_pane_rejects_non_finite_data():
 
 @pytest.mark.parametrize("viewer_cls", NAMED_VIEWERS)
 def test_named_viewer_constructs_before_first_sample(drawing_display, viewer_cls):
-    viewer_cls(MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL))
+    viewer_cls(MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20))
     assert drawing_display[0].updates == 0
 
 
 @pytest.mark.parametrize("viewer_cls", NAMED_VIEWERS)
 @pytest.mark.parametrize("every", [1, 3])
 def test_named_viewer_updates_at_any_sampling_cadence(drawing_display, viewer_cls, every):
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     viewer = viewer_cls(simulation)
     for _ in range(6):
         simulation.step()
@@ -573,7 +566,7 @@ def test_failed_pane_setup_closes_its_figure(drawing_display):
             raise ValueError("this pane cannot be set up")
 
     plt.close("all")
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     with pytest.raises(ValueError, match="cannot be set up"):
         Viewer(simulation, [FailingPane()])
     assert plt.get_fignums() == []
@@ -586,7 +579,7 @@ def test_failed_first_draw_closes_the_figure_without_opening_a_display(drawing_d
             raise RuntimeError("this pane cannot draw")
 
     plt.close("all")
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     with pytest.raises(RuntimeError, match="cannot draw"):
         Viewer(simulation, [FailingPane()])
     assert plt.get_fignums() == []
@@ -594,7 +587,7 @@ def test_failed_first_draw_closes_the_figure_without_opening_a_display(drawing_d
 
 
 def test_cell_pane_tolerates_extra_artists_on_its_axes(drawing_display):
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     viewer = JustCell(simulation)
     line = viewer.axes[0].lines[0]
     before = [data.copy() for data in line.get_data()]
@@ -604,7 +597,7 @@ def test_cell_pane_tolerates_extra_artists_on_its_axes(drawing_display):
 
 
 def test_rdf_pane_on_a_single_atom_draws_nothing(drawing_display):
-    simulation = MCSimulation.initialise(number_of_atoms=1, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=1, temperature=100, box=20)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         viewer = RDF(simulation)
@@ -613,7 +606,7 @@ def test_rdf_pane_on_a_single_atom_draws_nothing(drawing_display):
 
 
 def test_average_with_no_history_leaves_the_line_alone(drawing_display):
-    simulation = MCSimulation.initialise(number_of_atoms=1, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MCSimulation.initialise(ARGON_MODEL, number_of_atoms=1, temperature=100, box=20)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         viewer = RDF(simulation)
@@ -630,7 +623,7 @@ def test_energy_viewer_on_mc_system(drawing_display):
 
 
 def test_rdf_viewer_average_shows_the_mean(drawing_display):
-    simulation = MDSimulation.initialise(number_of_atoms=20, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=20, temperature=100, box=20)
     viewer = RDF(simulation)
     history = [viewer.axes[1].lines[0].get_ydata().copy()]
     for _ in range(3):
@@ -643,38 +636,36 @@ def test_rdf_viewer_average_shows_the_mean(drawing_display):
 
 
 def test_average_is_available_before_any_update(drawing_display):
-    RDF(
-        MDSimulation.initialise(number_of_atoms=20, temperature=100, box=20, **ARGON_MODEL)
-    ).average()
+    RDF(MDSimulation.initialise(ARGON_MODEL, number_of_atoms=20, temperature=100, box=20)).average()
 
 
 def test_average_rejects_viewers_without_history(drawing_display):
     with pytest.raises(ValueError):
         Energy(
-            MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+            MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
         ).average()
 
 
 def test_cell_plus_rejects_half_supplied_data(drawing_display):
     viewer = CellPlus(
-        MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL), "x", "y"
+        MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20), "x", "y"
     )
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     with pytest.raises(ValueError):
         viewer.update(simulation, [0, 1, 2])
 
 
 def test_cell_plus_rejects_y_data_without_x_data(drawing_display):
     viewer = CellPlus(
-        MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL), "x", "y"
+        MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20), "x", "y"
     )
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     with pytest.raises(ValueError):
         viewer.update(simulation, ydata=[1, 2])
 
 
 def test_cell_plus_takes_custom_data(drawing_display):
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     viewer = CellPlus(simulation, "x label", "y label")
     viewer.update(simulation, [0, 1, 2], [1, 4, 9])
     assert_allclose(viewer.axes[1].lines[0].get_ydata(), [1, 4, 9])
@@ -682,14 +673,14 @@ def test_cell_plus_takes_custom_data(drawing_display):
 
 def test_viewer_forwards_size_to_environment(drawing_display):
     viewer = JustCell(
-        MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL),
+        MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20),
         size="small",
     )
     assert viewer.fig.get_figwidth() == 2
 
 
 def test_viewer_without_kernel(capsys):
-    simulation = MDSimulation.initialise(number_of_atoms=4, temperature=100, box=20, **ARGON_MODEL)
+    simulation = MDSimulation.initialise(ARGON_MODEL, number_of_atoms=4, temperature=100, box=20)
     viewer = JustCell(simulation)
     viewer.update(simulation)
     assert capsys.readouterr().out == ""

--- a/pylj/tests/test_simulation.py
+++ b/pylj/tests/test_simulation.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import md, placement, simulation
-from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, WELL_MODEL
+from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, MIXTURE_MODEL, WELL_MODEL
 
 
 class TestInitialEnergyCheck(unittest.TestCase):
@@ -88,6 +88,10 @@ class TestSimulation(unittest.TestCase):
         c = placement.place_square(4, (LARGER,), 40e-10)
         with self.assertRaisesRegex(ValueError, "larger.*not in the model"):
             Counting(c, ARGON_MODEL)
+
+    def test_accepts_a_configuration_using_some_of_the_model_species(self):
+        c = placement.place_square(4, (ARGON,), 40e-10)
+        self.assertIs(Counting(c, MIXTURE_MODEL).model, MIXTURE_MODEL)
 
     def test_step_and_sample_are_abstract(self):
         class Stepless(simulation.Simulation):

--- a/pylj/tests/test_simulation.py
+++ b/pylj/tests/test_simulation.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from pylj import md, placement, simulation
-from pylj.tests.argon import ARGON, ARGON_MODEL, WELL_MODEL
+from pylj.tests.argon import ARGON, ARGON_MODEL, LARGER, WELL_MODEL
 
 
 class TestInitialEnergyCheck(unittest.TestCase):
@@ -12,13 +12,13 @@ class TestInitialEnergyCheck(unittest.TestCase):
         # 16 argon on a 4 by 4 lattice in a 10 Angstrom box are 2.5 Angstrom
         # apart, inside sigma: about 90 k_B T of potential energy per atom.
         c = placement.place_square(16, (ARGON,), 10e-10)
-        energy = c.potential_energy(ARGON_MODEL["pair_potentials"], 5e-10)
+        energy = c.potential_energy(ARGON_MODEL, 5e-10)
         with self.assertRaisesRegex(ValueError, "k_B T of potential energy"):
             simulation._check_initial_energy(energy, 16, 300)
 
     def test_refuses_a_lattice_inside_a_hard_core(self):
         c = placement.place_square(16, (ARGON,), 10e-10)
-        energy = c.potential_energy(WELL_MODEL["pair_potentials"], 5e-10)
+        energy = c.potential_energy(WELL_MODEL, 5e-10)
         with self.assertRaisesRegex(ValueError, "not finite"):
             simulation._check_initial_energy(energy, 16, 300)
 
@@ -26,7 +26,7 @@ class TestInitialEnergyCheck(unittest.TestCase):
         # 16 argon in a 12 Angstrom box store about 5.6 k_B T per atom
         # at 300 K, under the limit of 10.
         c = placement.place_square(16, (ARGON,), 12e-10)
-        energy = c.potential_energy(ARGON_MODEL["pair_potentials"], 6e-10)
+        energy = c.potential_energy(ARGON_MODEL, 6e-10)
         simulation._check_initial_energy(energy, 16, 300)
 
 
@@ -48,12 +48,12 @@ class Counting(simulation.Simulation):
 class TestSimulation(unittest.TestCase):
     def build(self, box=40e-10, **kwargs):
         c = placement.place_square(4, (ARGON,), box)
-        return Counting(c, ARGON_MODEL["pair_potentials"], **kwargs)
+        return Counting(c, ARGON_MODEL, **kwargs)
 
     def test_holds_the_configuration_and_the_model(self):
         s = self.build(seed=1)
         self.assertEqual(s.configuration.number_of_atoms, 4)
-        self.assertEqual(s.pair_potentials, ARGON_MODEL["pair_potentials"])
+        self.assertIs(s.model, ARGON_MODEL)
         self.assertEqual(s.steps, 0)
         self.assertIsInstance(s.samples, simulation.Samples)
         self.assertEqual(s.samples.step.size, 0)
@@ -84,10 +84,10 @@ class TestSimulation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "exceeds half the box"):
             self.build(cut_off=25e-10)
 
-    def test_validates_the_model(self):
-        c = placement.place_square(4, (ARGON,), 40e-10)
-        with self.assertRaisesRegex(ValueError, "no entry for the pair"):
-            Counting(c, {})
+    def test_refuses_a_configuration_species_outside_the_model(self):
+        c = placement.place_square(4, (LARGER,), 40e-10)
+        with self.assertRaisesRegex(ValueError, "larger.*not in the model"):
+            Counting(c, ARGON_MODEL)
 
     def test_step_and_sample_are_abstract(self):
         class Stepless(simulation.Simulation):
@@ -96,7 +96,7 @@ class TestSimulation(unittest.TestCase):
 
         c = placement.place_square(4, (ARGON,), 40e-10)
         with self.assertRaisesRegex(TypeError, "step"):
-            Stepless(c, ARGON_MODEL["pair_potentials"])
+            Stepless(c, ARGON_MODEL)
 
     def test_restart_starts_a_fresh_record_and_shares_the_model(self):
         s = self.build(seed=1)
@@ -107,7 +107,7 @@ class TestSimulation(unittest.TestCase):
         self.assertIsNot(production, s)
         self.assertIsInstance(production, Counting)
         self.assertIs(production.configuration, s.configuration)
-        self.assertIs(production.pair_potentials, s.pair_potentials)
+        self.assertIs(production.model, s.model)
         self.assertEqual(production.steps, 0)
         self.assertIsNot(production.samples, s.samples)
         self.assertEqual(production.samples.step.size, 0)


### PR DESCRIPTION
Adds `pylj.model.Model`, the species and the potential between each pair of them, as one type validated when it is built. `Model.single(species, potential)` builds the one-species case and `Model.potential(one, other)` looks a pair up in either order.

`MDSimulation.initialise` and `MCSimulation.initialise` take the model as their one positional argument in place of the `species` and `pair_potentials` keywords, and the constructors take it in place of `pair_potentials`; a simulation holds it as `model`. `Configuration.pairs`, `potential_energy`, `forces`, `virial` and `insertion_energy`, `md.velocity_verlet`, `placement.place` and `placement.place_metropolis` take it likewise. `Simulation.__init__` checks that every species in a hand-built configuration is in the model. `pairwise.pair_potential` and the `PairPotentials` alias are removed.

The README and every documentation page use `Model.single` for one species and the full constructor for the mixture example; `pylj.model` joins the module reference. Changelog entry under Unreleased.

Closes #106
