### PR TITLE
Rewrite the docstrings to document the code

### DIFF
--- a/pylj/__init__.py
+++ b/pylj/__init__.py
@@ -6,5 +6,5 @@ __version__ = "2.0.0b1"
 
 
 def __cite__() -> None:  # pragma: no cover
-    """Open the JOSE paper on pylj in a browser."""
+    """Opens the JOSE paper on pylj in a browser."""
     webbrowser.open("http://jose.theoj.org/papers/58daa1a1a564dc8e0f99ffcdae20eb1d")

--- a/pylj/configuration.py
+++ b/pylj/configuration.py
@@ -1,4 +1,4 @@
-"""Configurations: the physical state a simulation evolves."""
+"""Atom configurations."""
 
 import dataclasses
 from dataclasses import dataclass
@@ -16,19 +16,15 @@ from pylj.scattering import check_q_max, default_q_max, shell_average, wavevecto
 
 @dataclass(frozen=True, eq=False)
 class PairData:
-    """The distance, separation, energy and force of every pair of atoms.
-
-    Each pair appears once, in the order :func:`pairwise.dist` returns them:
-    the atom with the lower index first.
+    """The result of :meth:`Configuration.pairs`.
 
     Attributes:
         distance: The minimum-image distance between each pair, in metres.
-        separation: The minimum-image separation ``r_i - r_j`` of each pair,
-            shape ``(M, 2)``, in metres.
-        energy: The energy of each pair, in joules; zero beyond the cut-off.
+        separation: The minimum-image separation of each pair, ``r_i - r_j``
+            with ``i < j``, shape ``(M, 2)``, in metres.
+        energy: The energy of each pair, in joules.
         radial_force: The radial force on each pair, in newtons, positive
-            where repulsive and zero beyond the cut-off; ``None`` when the
-            forces were not evaluated.
+            where repulsive; ``None`` if it was not evaluated.
     """
 
     distance: NDArray[np.float64]
@@ -43,7 +39,11 @@ class PairData:
 
 
 def _radial_force(pairs: PairData) -> NDArray[np.float64]:
-    """Return the radial forces, raising if the pair data was evaluated without them."""
+    """Returns the radial forces.
+
+    Raises:
+        ValueError: If the pair data was evaluated without forces.
+    """
     if pairs.radial_force is None:
         raise ValueError("The pair forces were not evaluated; call pairs(..., forces=True)")
     return pairs.radial_force
@@ -51,18 +51,11 @@ def _radial_force(pairs: PairData) -> NDArray[np.float64]:
 
 @dataclass(frozen=True, eq=False)
 class Configuration:
-    """Where the atoms are: the state a Monte Carlo simulation evolves.
-
-    A configuration cannot be changed once it is made, and it holds no
-    description of how the atoms interact. Each method that evaluates the
-    interactions between atoms is given a ``Model`` and a ``cut_off`` when it
-    is called, so the same configuration can be evaluated under different
-    potentials. Everything is in SI units.
+    """A single configuration of atoms and the simulation cell.
 
     Attributes:
-        position: The position of each atom, shape ``(N, 2)``, in
-            metres; a simulation keeps them wrapped into the box.
-        species: The species in the configuration.
+        position: The position of each atom, shape ``(N, 2)``, in metres.
+        species: The distinct species, indexed by ``species_index``.
         species_index: The index in ``species`` of each atom's species,
             shape ``(N,)``.
         box: The side length of the square periodic box, in metres.
@@ -99,22 +92,20 @@ class Configuration:
 
     @property
     def number_of_atoms(self) -> int:
-        """The number of atoms."""
         return self.position.shape[0]
 
     @property
     def masses(self) -> NDArray[np.float64]:
-        """The mass of each atom, in kilograms, from its species."""
+        """Atomic masses, in kilograms."""
         masses = np.array([one.mass for one in self.species], dtype=float) * ATOMIC_MASS_UNIT
         return masses[self.species_index]
 
     def replace(self, **changes: Any) -> Self:
-        """Return a copy with the given fields replaced. The copy is checked in the same
-        way as any other configuration."""
+        """Returns a copy with the given fields replaced."""
         return dataclasses.replace(self, **changes)
 
     def without(self, index: int) -> Self:
-        """Return a copy with one atom removed.
+        """Returns a copy of this Configuration with one atom removed.
 
         Args:
             index: The index of the atom to remove.
@@ -130,27 +121,19 @@ class Configuration:
         return dataclasses.replace(self, **arrays)
 
     def pairs(self, model: Model, cut_off: float, *, forces: bool = False) -> PairData:
-        """Evaluate every pair of atoms under the model.
+        """Evaluates the energy and optionally forces for each pair of atoms.
 
-        Each pair is separated by its minimum-image distance, and the potential
-        for the two species it joins gives its energy. A pair further apart
-        than the cut-off contributes nothing. A pair closer than its
-        potential's ``min_separation`` is forbidden: its energy is infinite,
-        and if forces are requested the evaluation raises, since the
-        simulation has entered a region where the model is unphysical. The
-        forces are evaluated only when ``forces`` is requested, so a
-        potential that has no finite force, such as the square well, can
-        still be used here.
+        A pair further apart than the cut-off has zero energy and force, and
+        a pair closer than its potential's ``min_separation`` has infinite
+        energy and raises if forces are requested.
 
         Args:
-            model: The species and the potential between each pair of them.
-            cut_off: The separation beyond which a pair contributes nothing,
-                in metres.
-            forces: Whether to evaluate the radial forces as well.
+            model: The model.
+            cut_off: The cut-off, in metres.
+            forces: Whether to evaluate the radial forces.
 
         Returns:
-            The pair distances, separations, energies and, if requested,
-            forces.
+            The pair data.
 
         Raises:
             ValueError: If forces are requested and a pair is closer than
@@ -182,11 +165,11 @@ class Configuration:
         return PairData(distance, separation, energy, force)
 
     def potential_energy(self, model: Model, cut_off: float) -> float:
-        """The total pair energy, in joules."""
+        """Computes the total pair energy, in joules."""
         return float(self.pairs(model, cut_off).energy.sum())
 
     def forces(self, model: Model, cut_off: float) -> NDArray[np.float64]:
-        """The net force on each atom, shape ``(N, 2)``, in newtons."""
+        """Computes the net force on each atom, shape ``(N, 2)``, in newtons."""
         pairs = self.pairs(model, cut_off, forces=True)
         radial = _radial_force(pairs)
         i, j = np.triu_indices(self.number_of_atoms, 1)
@@ -199,7 +182,8 @@ class Configuration:
         return force
 
     def virial(self, model: Model, cut_off: float) -> float:
-        """The sum over pairs of the radial force times the distance, in joules."""
+        """Computes the sum over pairs of the radial force times the distance,
+        in joules."""
         return self.pairs(model, cut_off, forces=True).virial
 
     def insertion_energy(
@@ -209,15 +193,14 @@ class Configuration:
         model: Model,
         cut_off: float,
     ) -> float:
-        """Return the interaction energy of one added atom with the atoms already
+        """Computes the interaction energy of one added atom with the atoms already
         in the configuration.
 
         Args:
             position: The ``(x, y)`` position of the added atom, in metres.
-            species_index: The index in ``species`` of its species.
-            model: The species and the potential between each pair of them.
-            cut_off: The separation beyond which a pair contributes nothing,
-                in metres.
+            species_index: The index in ``species`` of the added atom's species.
+            model: The model.
+            cut_off: The cut-off, in metres.
 
         Returns:
             The sum of its pair energies, in joules; zero for an empty
@@ -239,29 +222,20 @@ class Configuration:
     def rdf(
         self, bins: int = 100, r_max: float | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Return the radial distribution function g(r) of this configuration.
+        """Computes the radial distribution function g(r) of this configuration.
 
-        The pair distances are sorted into bins from zero to ``r_max``. The
-        count in each bin is divided by the count an ideal gas of the same
-        density would give. That gas has ``N (N - 1) / 2`` pairs spread
-        evenly over the box, and a ring of radius ``r`` and width ``dr``
-        holds the fraction ``2 pi r dr / L^2`` of them, where ``L`` is the
-        box length. So g(r) is one where the atoms are spread as evenly as
-        an ideal gas, above one where they gather and below one where they
-        avoid each other.
+        The pair distances are binned from zero to ``r_max`` and divided by
+        the counts an ideal gas of the same density would give.
 
         Args:
             bins: The number of bins.
             r_max: The largest distance binned, in metres. By default half
-                the box, the furthest a minimum-image distance can reach in
-                every direction. Past half the box the ring runs outside the
-                square, so the ideal-gas count is too large and g(r) sinks
-                towards zero even for a uniform gas.
+                the box, beyond which the ideal-gas normalisation no longer
+                holds.
 
         Returns:
-            The centre of each bin, in metres, and g(r) at each. A
-            configuration of one atom has no pairs, so g(r) is zero
-            everywhere.
+            The bin centres, in metres, and g(r) in each bin.
+            Returns zero everywhere for a configuration containing one atom.
         """
         if r_max is None:
             r_max = self.box / 2
@@ -280,24 +254,20 @@ class Configuration:
     def structure_factor(
         self, q_max: float | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Return the structure factor S(q) of this configuration.
+        """Computes the structure factor S(q) of this configuration.
 
         S(q) is evaluated at the wavevectors commensurate with the box,
-        ``2 pi (h, k) / L``, where ``L`` is the box length and ``h`` and
-        ``k`` are integers that are not both zero. Each wavevector ``q`` has
-        an amplitude ``sum_j exp(i q . r_j)``, summed over the atom positions
-        ``r_j``. S(q) at that wavevector is the square of the modulus of the
-        amplitude, divided by the number of atoms. Every atom counts alike,
-        whatever its species. The wavevectors that share a magnitude are
-        averaged together, so the result holds one value per magnitude.
+        ``2 pi (h, k) / L`` for integers ``h`` and ``k`` not both zero.
+        Wavevectors of equal magnitude are averaged together, so the result
+        holds one value per magnitude. Every atom counts alike, whatever its
+        species.
 
         Args:
-            q_max: The largest wavevector magnitude, in 1/m. By default six
-                times ``2 pi sqrt(N) / L``, the wavevector that matches the
-                mean spacing between the ``N`` atoms.
+            q_max: The largest wavevector magnitude, in 1/m; the default
+                comes from :func:`~pylj.scattering.default_q_max`.
 
         Returns:
-            The wavevector magnitudes, in 1/m, and S(q) at each.
+            The wavevector magnitudes, in 1/m, and S(q) at each magnitude.
 
         Raises:
             ValueError: If ``q_max`` is below ``2 pi / L``.
@@ -311,22 +281,17 @@ class Configuration:
 
 @dataclass(frozen=True, eq=False)
 class MDConfiguration(Configuration):
-    """Where the atoms are and how fast they move: the state a molecular
-    dynamics simulation evolves.
-
-    An atom carries its momentum, so :meth:`Configuration.without` leaves
-    the rest with a net momentum. :func:`~pylj.md.at_rest` clears it, and
-    :class:`~pylj.md.MDSimulation` does so for whatever it is built from.
+    """A configuration with atom velocities and unwrapped positions.
 
     Attributes:
         velocity: The velocity of each atom, shape ``(N, 2)``, in
             metres per second.
         unwrapped: The position of each atom without periodic wrapping,
-            shape ``(N, 2)``, in metres, for the mean squared displacement.
+            shape ``(N, 2)``, in metres.
 
     Raises:
         ValueError: If ``velocity`` or ``unwrapped`` is not the shape of
-            ``position``, or for anything :class:`Configuration` rejects.
+            ``position``.
     """
 
     velocity: NDArray[np.float64]
@@ -342,17 +307,14 @@ class MDConfiguration(Configuration):
                 )
 
     def kinetic_energy(self) -> float:
-        """The total kinetic energy, in joules."""
+        """Computes the total kinetic energy, in joules."""
         return float(0.5 * np.sum(self.masses * np.sum(self.velocity**2, axis=1)))
 
     def temperature(self) -> float:
-        """The instantaneous temperature, in kelvin.
+        """Computes the instantaneous temperature, in kelvin.
 
-        A simulation sets the centre of mass at rest whichever way it is
-        built, and the pair forces cannot set it moving. Two of the ``2N``
-        velocity components are therefore fixed by that condition, leaving
-        ``2N - 2`` to carry thermal energy. The temperature is the kinetic
-        energy divided by ``(N - 1) k_B``.
+        The kinetic energy divided by ``(N - 1) k_B``, the centre of mass
+        being at rest.
 
         Raises:
             ValueError: If there are fewer than two atoms.
@@ -365,11 +327,9 @@ class MDConfiguration(Configuration):
         return self.kinetic_energy() / ((self.number_of_atoms - 1) * BOLTZMANN)
 
     def msd(self, initial: "MDConfiguration") -> float:
-        """Return the mean squared displacement since an earlier configuration.
+        """Computes the mean squared displacement since an earlier configuration.
 
-        The unwrapped positions are used, so an atom that crosses the edge
-        of the box and reappears on the other side counts as having travelled
-        the whole way.
+        Measured from the unwrapped positions.
 
         Args:
             initial: The configuration to measure the displacement from.

--- a/pylj/constants.py
+++ b/pylj/constants.py
@@ -1,4 +1,4 @@
-"""Physical constants used throughout pylj, in SI units."""
+"""Physical constants, in SI units."""
 
 from scipy.constants import atomic_mass, k
 

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -1,6 +1,4 @@
-"""Monte Carlo: the simulation that samples configurations by the Metropolis
-criterion, the criterion itself, and the proposed move the criterion accepts or
-rejects."""
+"""Metropolis Monte Carlo simulation."""
 
 from dataclasses import dataclass, field
 from typing import Self
@@ -24,7 +22,7 @@ from pylj.simulation import (
 
 @dataclass
 class MCSamples(Samples):
-    """What a Monte Carlo simulation records at each sample.
+    """The record a Monte Carlo simulation appends to at each sample.
 
     Attributes:
         potential_energy: The total pair energy, in joules.
@@ -35,17 +33,14 @@ class MCSamples(Samples):
 
 @dataclass(frozen=True, eq=False)
 class Proposal:
-    """A proposed configuration for a Monte Carlo move.
-
-    The energy change is relative to the configuration the proposal was made
-    from, so a proposal can only be applied while that configuration is
-    still the current one.
+    """A proposed configuration for a Monte Carlo move, and the corresponding
+    energy change.
 
     Attributes:
         position: The proposed position of every atom, shape ``(N, 2)``,
             in metres.
-        energy_change: The energy of the proposed configuration minus that
-            of ``source``, in joules.
+        energy_change: The change in energy under the proposed move, in
+            joules.
         source: The configuration the proposal was made from.
     """
 
@@ -61,15 +56,11 @@ def accept(
     random_number: float | None = None,
     rng: np.random.Generator | None = None,
 ) -> bool:
-    """Apply the Metropolis criterion to an energy change.
-
-    A change that does not raise the energy is always accepted, without
-    drawing a random number. A change that raises it by ``energy_change`` is
-    accepted with probability ``exp(-energy_change / (k_B temperature))``.
+    """Applies the Metropolis criterion to an energy change.
 
     Args:
-        energy_change: The energy of the proposed configuration minus that
-            of the current one, in joules.
+        energy_change: The change in energy under the proposed move, in
+            joules.
         temperature: The temperature the acceptance is judged at, in kelvin.
         random_number: The uniform random number the acceptance probability
             is tested against. By default one is drawn from ``rng``.
@@ -89,37 +80,27 @@ def accept(
 
 
 class MCSimulation(Simulation):
-    """A Monte Carlo simulation at a temperature.
-
-    ``step`` proposes a move, accepts it by the Metropolis criterion or
-    leaves the configuration as it is, and advances the step count;
-    ``sample`` records the exact energy.
+    """A Monte Carlo simulation.
 
     Args:
-        configuration: The starting configuration. An ``MDConfiguration``
-            is accepted; its velocities are ignored.
-        model: The species and the potential between each pair of them.
-            Only the pair energies are evaluated, so a potential with no
-            finite force, such as the square well, can be used.
+        configuration: The starting configuration.
+        model: The model.
         temperature: The temperature of the simulation, in kelvin.
         cut_off: The cut-off, in metres; see :class:`Simulation`.
         seed: Seed for the random number generator.
 
     Attributes:
         temperature: The temperature, in kelvin.
-        energy: The total pair energy of the current configuration, in joules.
-            It is computed when the simulation is built, updated by ``apply``
-            each time a move is accepted, and recomputed exactly each time
-            ``sample`` is called.
+        energy: The total pair energy of the current configuration, in
+            joules.
         accepted: The number of moves accepted so far.
         samples: The :class:`MCSamples` record that ``sample`` appends to.
 
     Raises:
         ValueError: If the temperature is not positive and finite, a pair
-            potential has not died away at the cut-off, the configuration
+            potential has not died away at the cut-off, or the configuration
             stores more than :data:`simulation.INITIAL_ENERGY_LIMIT` k_B T of
-            potential energy per atom, or for anything
-            :class:`Simulation` rejects.
+            potential energy per atom.
     """
 
     samples: MCSamples
@@ -156,31 +137,33 @@ class MCSimulation(Simulation):
         cut_off: float | None = None,
         seed: int | None = None,
     ) -> Self:
-        """Build a simulation from a model: place the atoms and set the
-        temperature.
+        """Builds a simulation from a model.
+
+        Places the atoms in the box.
 
         Args:
-            model: The species, assigned to the atoms in turn, and the
-                potential between each pair of them.
+            model: The model.
             number_of_atoms: The number of atoms.
             temperature: The temperature of the simulation, in kelvin.
-            box: The side length of the box, in Angstrom, from 4 to 600.
-            init_conf: ``'square'`` for a square lattice, ``'triangular'``
-                for a triangular one, or ``'metropolis'`` for sequential
-                Metropolis insertion.
+            box: The side length of the box, in Angstrom, from
+                :data:`~pylj.placement.SMALLEST_BOX` to :data:`~pylj.placement.LARGEST_BOX`.
+            init_conf: How the atoms are placed. ``'square'`` puts them on a
+                square grid, ``'triangular'`` on a triangular lattice filling
+                the box, which constrains the number of atoms, and
+                ``'metropolis'`` inserts them at random positions for a
+                disordered start.
             placement_temperature: The temperature of the Metropolis
                 acceptance used by ``'metropolis'``, in kelvin; by default
-                the run temperature. Raising it tolerates closer contacts,
-                lowering it rejects them more strictly and can exhaust the
-                trial budget.
-            max_strain: How far the fitted lattice may sit from
-                ``sqrt(3) / 2``, as a fraction of that ratio, when
-                ``init_conf`` is ``'triangular'``. Used only by that
-                placement.
-            cut_off: The cut-off, in Angstrom; by default 15 Angstrom or
-                half the box, whichever is smaller.
+                the run temperature.
+            max_strain: If ``init_conf`` is ``'triangular'``, how far the
+                fitted lattice may sit from
+                ``sqrt(3) / 2``, as a fraction of that ratio.
+            cut_off: The cut-off, in Angstrom; by default
+                :data:`~pylj.simulation.DEFAULT_CUT_OFF` Angstrom or half the
+                box, whichever is smaller.
             seed: Seed for the random number generator used to place the
-                configuration and make the moves.
+                configuration and make the moves; without one the run differs
+                each time.
 
         Returns:
             The simulation, with its energy evaluated.
@@ -206,15 +189,10 @@ class MCSimulation(Simulation):
         return simulation
 
     def propose(self) -> Proposal:
-        """Propose a move: one atom relocated at random.
-
-        An atom is chosen at random and given a uniform trial position in
-        the box. The energy change is that atom's interaction energy at
-        the trial position minus that at its current position, with every
-        other atom. The configuration is not changed.
+        """Proposes moving one atom to a random position.
 
         Returns:
-            The proposed configuration and its energy change.
+            The proposal.
         """
         configuration = self.configuration
         atom = int(self.rng.integers(configuration.number_of_atoms))
@@ -230,20 +208,14 @@ class MCSimulation(Simulation):
         return Proposal(position, energy_change, configuration)
 
     def apply(self, proposal: Proposal) -> None:
-        """Make a proposed configuration the current one.
-
-        The configuration takes the proposal's positions, and the proposal's
-        energy change is added to ``energy``.
+        """Applies a proposal, replacing the configuration with its positions.
 
         Args:
-            proposal: The proposal to apply, from :meth:`propose`.
+            proposal: The proposal.
 
         Raises:
             ValueError: If the proposal was made from a configuration other
-                than the current one, so its energy change no longer
-                applies. This happens when two proposals are made and both
-                are applied: the second must be proposed after the first is
-                applied.
+                than the current one.
         """
         if proposal.source is not self.configuration:
             raise ValueError(
@@ -255,8 +227,7 @@ class MCSimulation(Simulation):
         self.energy += proposal.energy_change
 
     def step(self) -> None:
-        """Propose a move, accept it by the Metropolis criterion or leave
-        the configuration as it is, and advance the step count."""
+        """Proposes a move and accept or reject it by the Metropolis criterion."""
         proposal = self.propose()
         if accept(proposal.energy_change, self.temperature, rng=self.rng):
             self.apply(proposal)
@@ -264,19 +235,17 @@ class MCSimulation(Simulation):
         self.steps += 1
 
     def sample(self) -> None:
-        """Record the configuration in the trajectory and measure it.
+        """Records the configuration in the trajectory and measures it.
 
-        The step and the potential energy go into the samples. The energy
-        is recomputed from the configuration first, so the
-        recorded value is exact; between samples ``apply`` keeps a running
-        total.
+        The energy is recomputed from the configuration, so the recorded
+        value is exact.
         """
         self.trajectory.append(self.configuration)
         self.energy = self.configuration.potential_energy(self.model, self.cut_off)
         self.samples.add(step=self.steps, potential_energy=self.energy)
 
     def restart(self) -> Self:
-        """A new simulation that continues from the current configuration.
+        """Returns a new simulation continuing from the current configuration.
 
         See :meth:`Simulation.restart`.
         """

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -1,6 +1,4 @@
-"""Molecular dynamics: the simulation that integrates Newton's equations of
-motion, the Velocity-Verlet integrator, and the velocity-rescaling
-thermostat."""
+"""Molecular dynamics simulation."""
 
 from dataclasses import dataclass, field
 from typing import Self
@@ -25,7 +23,7 @@ from pylj.simulation import (
 
 @dataclass
 class MDSamples(Samples):
-    """What a molecular dynamics simulation records at each sample.
+    """The record a molecular dynamics simulation appends to at each sample.
 
     Attributes:
         temperature: The instantaneous temperature, in kelvin.
@@ -51,16 +49,11 @@ class MDSamples(Samples):
 class MDSimulation(Simulation):
     """A molecular dynamics simulation.
 
-    Between steps the simulation holds two things: the configuration, and the
-    force on each atom at that configuration. Velocity-Verlet needs both to
-    take the next step. ``step`` integrates one timestep and advances the
-    clock; ``sample`` measures the configuration.
-
     Args:
         configuration: The starting configuration, with velocities. The
             simulation starts from a copy with the centre of mass at rest;
             see :func:`at_rest`.
-        model: The species and the potential between each pair of them.
+        model: The model.
         cut_off: The cut-off, in metres; see :class:`Simulation`.
         timestep: The length of each integration step, in seconds.
         seed: Seed for the random number generator.
@@ -78,10 +71,9 @@ class MDSimulation(Simulation):
         TypeError: If ``configuration`` is not an ``MDConfiguration``.
         ValueError: If the timestep is not positive and finite, the
             configuration is at rest or has a non-finite temperature, a pair
-            potential has not died away at the cut-off, the configuration
+            potential has not died away at the cut-off, or the configuration
             stores more than :data:`simulation.INITIAL_ENERGY_LIMIT` k_B T
-            of potential energy per atom, or for anything
-            :class:`Simulation` rejects.
+            of potential energy per atom.
     """
 
     configuration: MDConfiguration
@@ -141,39 +133,37 @@ class MDSimulation(Simulation):
         cut_off: float | None = None,
         seed: int | None = None,
     ) -> Self:
-        """Build a simulation from a model: place the atoms and draw
-        their velocities at a temperature.
+        """Builds a simulation from a model.
 
-        Each component of each velocity is drawn from a normal distribution
-        of width ``sqrt(k_B T / m)``, where ``m`` is the mass of that atom,
-        so heavier atoms move more slowly. The centre of mass is put at
-        rest, then every velocity is scaled by the same factor, so that the
-        instantaneous temperature is exactly the one requested. The
-        temperature is not stored: molecular dynamics measures it.
+        Places the atoms in the box and draws their velocities at random,
+        scaled so the initial temperature is exactly the one asked for. The
+        temperature is not stored: a molecular dynamics run measures its own.
 
         Args:
-            model: The species, assigned to the atoms in turn, and the
-                potential between each pair of them.
+            model: The model.
             number_of_atoms: The number of atoms, at least two.
             temperature: The initial temperature, in kelvin.
-            box: The side length of the box, in Angstrom, from 4 to 600.
-            init_conf: ``'square'`` for a square lattice, ``'triangular'``
-                for a triangular one, or ``'metropolis'`` for sequential
-                Metropolis insertion.
+            box: The side length of the box, in Angstrom, from
+                :data:`~pylj.placement.SMALLEST_BOX` to :data:`~pylj.placement.LARGEST_BOX`.
+            init_conf: How the atoms are placed. ``'square'`` puts them on a
+                square grid, ``'triangular'`` on a triangular lattice filling
+                the box, which constrains the number of atoms, and
+                ``'metropolis'`` inserts them at random positions for a
+                disordered start.
             placement_temperature: The temperature of the Metropolis
                 acceptance used by ``'metropolis'``, in kelvin; by default
-                the run temperature. Raising it tolerates closer contacts,
-                lowering it rejects them more strictly and can exhaust the
-                trial budget.
+                the run temperature.
             max_strain: How far the fitted lattice may sit from
                 ``sqrt(3) / 2``, as a fraction of that ratio, when
                 ``init_conf`` is ``'triangular'``. Used only by that
                 placement.
             timestep: The length of each integration step, in seconds.
-            cut_off: The cut-off, in Angstrom; by default 15 Angstrom or
-                half the box, whichever is smaller.
+            cut_off: The cut-off, in Angstrom; by default
+                :data:`~pylj.simulation.DEFAULT_CUT_OFF` Angstrom or half the
+                box, whichever is smaller.
             seed: Seed for the random number generator used to place the
-                configuration, draw the velocities and continue the run.
+                configuration, draw the velocities and continue the run;
+                without one the run differs each time.
 
         Returns:
             The simulation, with its forces evaluated.
@@ -222,32 +212,29 @@ class MDSimulation(Simulation):
 
     @property
     def time(self) -> float:
-        """The simulated time, in seconds: the steps taken times the timestep."""
+        """The simulated time, in seconds."""
         return self.steps * self.timestep
 
     def integrate(self) -> None:
-        """Move the configuration one timestep forward with Velocity-Verlet,
+        """Moves the configuration one timestep forward with Velocity-Verlet,
         replacing the configuration and the forces.
-
-        A subclass with a different integrator overrides this method.
         """
         self.configuration, self.forces = velocity_verlet(
             self.configuration, self.forces, self.timestep, self.model, self.cut_off
         )
 
     def step(self) -> None:
-        """Integrate one timestep and advance the clock.
+        """Integrates one timestep and advance the clock.
 
         Raises:
             ValueError: If an atom moves further than half the cut-off in
-                the step, or a pair comes closer than its potential allows;
-                either way the run has diverged.
+                the step, or a pair comes closer than its potential allows.
         """
         self.integrate()
         self.steps += 1
 
     def heat_bath(self, bath_temperature: float) -> None:
-        """Rescale the velocities to the bath temperature.
+        """Rescales the velocities to the bath temperature.
 
         Args:
             bath_temperature: The desired temperature, in kelvin.
@@ -259,11 +246,8 @@ class MDSimulation(Simulation):
         self.configuration = heat_bath(self.configuration, bath_temperature)
 
     def sample(self) -> None:
-        """Record the configuration in the trajectory and measure it.
-
-        The step, temperature, pressure, potential and kinetic energies and
-        mean squared displacement go into the samples.
-        """
+        """Records the configuration in the trajectory and measures it into
+        :class:`MDSamples`."""
         self.trajectory.append(self.configuration)
         configuration = self.configuration
         kinetic_energy = configuration.kinetic_energy()
@@ -278,8 +262,8 @@ class MDSimulation(Simulation):
         )
 
     def restart(self) -> Self:
-        """A new simulation that continues from the current configuration,
-        with the mean squared displacement measured from it.
+        """Returns a new simulation continuing from the current configuration,
+        with the mean squared displacement measured from it again.
 
         See :meth:`Simulation.restart`.
         """
@@ -297,29 +281,23 @@ def velocity_verlet(
     model: Model,
     cut_off: float,
 ) -> tuple[MDConfiguration, NDArray[np.float64]]:
-    """Move a configuration one timestep forward with the Velocity-Verlet
+    """Moves a configuration one timestep forward with the Velocity-Verlet
     integrator.
-
-    The positions are advanced with the current velocities and
-    accelerations, the forces are evaluated at the new positions, and the
-    velocities are advanced with the mean of the old and new accelerations.
 
     Args:
         configuration: The configuration at time t.
         forces: The net force on each atom at that configuration, shape
             ``(N, 2)``, in newtons.
         timestep: The length of the step, in seconds.
-        model: The species and the potential between each pair of them.
+        model: The model.
         cut_off: The cut-off, in metres.
 
     Returns:
         The configuration at time t + dt and the forces at it.
 
     Raises:
-        ValueError: If an atom moves further than half the cut-off in
-            the one step. No atom moves that far in a run that is
-            behaving: the timestep is too long, or the run has already
-            diverged.
+        ValueError: If an atom moves further than half the cut-off in the
+            one step.
     """
     masses = configuration.masses[:, None]
     accelerations = forces / masses
@@ -343,8 +321,7 @@ def velocity_verlet(
 def update_positions(
     configuration: MDConfiguration, accelerations: NDArray[np.float64], timestep: float
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Advance the positions by the velocity times the timestep, plus half the
-    acceleration times the timestep squared.
+    """Advances the positions by one timestep.
 
     Args:
         configuration: The configuration to advance.
@@ -367,10 +344,11 @@ def update_velocities(
     next_accelerations: NDArray[np.float64],
     timestep: float,
 ) -> NDArray[np.float64]:
-    """Advance the velocities by the mean acceleration times the timestep.
+    """Advances the velocities by one timestep.
 
     Args:
-        velocity: The velocity of each atom, shape ``(N, 2)``.
+        velocity: The velocity of each atom, shape ``(N, 2)``, in metres
+            per second.
         accelerations: The accelerations at the start of the step.
         next_accelerations: The accelerations at the end of the step.
         timestep: The length of the step, in seconds.
@@ -382,13 +360,12 @@ def update_velocities(
 
 
 def at_rest(configuration: MDConfiguration) -> MDConfiguration:
-    """Return the configuration with its centre of mass at rest.
+    """Returns the configuration with its centre of mass at rest.
 
     The mass-weighted mean velocity is subtracted from every atom.
 
     Args:
-        configuration: The configuration whose centre of mass is to be
-            brought to rest.
+        configuration: The configuration to bring to rest.
 
     Returns:
         A copy with the centre of mass at rest.
@@ -399,18 +376,8 @@ def at_rest(configuration: MDConfiguration) -> MDConfiguration:
 
 
 def heat_bath(configuration: MDConfiguration, bath_temperature: float) -> MDConfiguration:
-    r"""Rescale the velocities so the instantaneous temperature equals the
+    """Rescales the velocities so the instantaneous temperature equals the
     bath temperature.
-
-    This is a velocity-rescaling thermostat: each call sets the
-    instantaneous temperature to the bath temperature, scaling every
-    velocity by
-
-    .. math::
-        \sqrt{T_{\text{bath}} / T_{\text{now}}}
-
-    where :math:`T_{\text{now}}` is the temperature of the current
-    velocities.
 
     Args:
         configuration: The configuration to thermostat.
@@ -421,8 +388,7 @@ def heat_bath(configuration: MDConfiguration, bath_temperature: float) -> MDConf
 
     Raises:
         ValueError: If the bath temperature is not positive and finite, the
-            atoms are at rest, or the current temperature is not finite
-            (the simulation has diverged).
+            atoms are at rest, or the current temperature is not finite.
     """
     check_positive_finite("bath_temperature", bath_temperature)
     current = configuration.temperature()

--- a/pylj/model.py
+++ b/pylj/model.py
@@ -1,5 +1,4 @@
-"""The physical model a simulation runs: the species and the potential
-between each pair of them."""
+"""Simulation models."""
 
 import itertools
 from collections.abc import Mapping, Sequence
@@ -12,7 +11,7 @@ from pylj.potentials import PairPotential, Species
 def _check_complete(
     species: tuple[Species, ...], pair_potentials: Mapping[tuple[Species, Species], PairPotential]
 ) -> None:
-    """Check that every pair of the species has exactly one potential and that
+    """Checks that every pair of the species has exactly one potential and that
     no other pair has one."""
     for pair in pair_potentials:
         if not isinstance(pair, tuple) or len(pair) != 2:
@@ -48,12 +47,10 @@ class Model:
 
     Every pair of species, including each species with itself, has one
     entry in ``pair_potentials``, keyed by the two species in either order.
-    ``single`` builds the model for one species. ``species`` and
-    ``pair_potentials`` are read-only.
 
     Args:
-        species: The species, as any sequence of ``Species``. Atoms are
-            assigned to them in turn when a configuration is placed.
+        species: The species, assigned to the atoms in turn when a
+            configuration is placed.
         pair_potentials: The potential between each pair of species.
 
     Raises:
@@ -106,17 +103,17 @@ class Model:
 
     @property
     def species(self) -> tuple[Species, ...]:
-        """The species, as a tuple, in the order atoms are assigned to them."""
+        """The species, in the order they are assigned to atoms."""
         return self._species
 
     @property
     def pair_potentials(self) -> Mapping[tuple[Species, Species], PairPotential]:
-        """The potential between each pair of species, as a read-only mapping."""
+        """The potential between each pair of species."""
         return MappingProxyType(self._pair_potentials)
 
     @classmethod
     def single(cls, species: Species, potential: PairPotential) -> Self:
-        """Build the model for one species.
+        """Builds the model for one species.
 
         Args:
             species: The one species.
@@ -125,7 +122,7 @@ class Model:
         return cls((species,), {(species, species): potential})
 
     def potential(self, one: Species, other: Species) -> PairPotential:
-        """Return the potential between two species.
+        """Looks up the potential between two species.
 
         The pair may be given in either order.
 

--- a/pylj/pairwise.py
+++ b/pylj/pairwise.py
@@ -1,6 +1,4 @@
-"""Calculations over every pair of atoms at once: grouping the atom pairs by
-the species they join, applying the minimum image convention, and getting the
-pressure from the virial."""
+"""Vectorised calculations over atom pairs."""
 
 from collections.abc import Iterator
 
@@ -11,12 +9,11 @@ from numpy.typing import NDArray
 def species_pairs(
     species_index: NDArray[np.int64],
 ) -> Iterator[tuple[NDArray[np.bool_], int, int]]:
-    """Group the atom pairs by the two species they join.
+    """Groups the atom pairs by the two species they join.
 
-    Each pair of species present is yielded once, because species 0 with
-    species 1 is the same pair as species 1 with species 0. Each comes with a
-    mask, which picks out the entries of the pair arrays returned by
-    :func:`dist` that join those two species.
+    Each pair of species present is yielded once, with a mask picking out
+    the entries of the pair arrays returned by :func:`dist` that join those
+    two species.
 
     Args:
         species_index: The species index of each atom.
@@ -32,7 +29,7 @@ def species_pairs(
 
 
 def minimum_image(separation: NDArray[np.float64], box: float) -> NDArray[np.float64]:
-    """Return separations wrapped to the nearest periodic image.
+    """Wraps separations to the nearest periodic image.
 
     Args:
         separation: Separation vectors, shape ``(..., 2)``, in metres.
@@ -48,7 +45,7 @@ def minimum_image(separation: NDArray[np.float64], box: float) -> NDArray[np.flo
 def dist(
     position: NDArray[np.float64], box: float
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Return the minimum-image distance and separation of every pair.
+    """Computes the minimum-image distance and separation of every pair.
 
     Args:
         position: The position of each atom, shape ``(N, 2)``, in
@@ -67,16 +64,10 @@ def dist(
 
 
 def calculate_pressure(virial: float, box: float, kinetic_energy: float) -> float:
-    r"""Return the instantaneous pressure of the cell in two dimensions.
+    r"""Computes the instantaneous pressure of the cell in two dimensions.
 
     .. math::
         p = \frac{1}{2 L^2} \left( 2 K + \sum_{i} \sum_{j > i} f_{ij} r_{ij} \right)
-
-    The kinetic term is the momentum the atoms carry across a line in
-    the cell. The centre of mass is held at rest, so over a run at
-    temperature ``T`` the kinetic energy averages ``(N - 1) k_B T`` and this
-    term averages ``(N - 1) k_B T / L^2``, one atom short of the
-    ideal-gas pressure ``N k_B T / L^2``.
 
     Args:
         virial: The sum over pairs of the radial force times the distance,
@@ -85,6 +76,6 @@ def calculate_pressure(virial: float, box: float, kinetic_energy: float) -> floa
         kinetic_energy: The total kinetic energy, in joules.
 
     Returns:
-        The pressure, in newtons per metre (a two-dimensional pressure).
+        The pressure, in newtons per metre.
     """
     return (2 * kinetic_energy + virial) / (2 * box * box)

--- a/pylj/placement.py
+++ b/pylj/placement.py
@@ -1,4 +1,4 @@
-"""The placement of initial configurations."""
+"""Initial atom positions."""
 
 import math
 from typing import NamedTuple
@@ -10,22 +10,25 @@ from pylj.model import Model
 from pylj.potentials import Species, check_positive_finite
 from pylj.simulation import _check_potentials_at_the_cut_off, _resolve_cut_off
 
+#: The smallest box, in Angstrom. Below this the cell cannot hold more
+#: than one atom.
+SMALLEST_BOX = 4
+
+#: The largest box, in Angstrom. Above this the atoms are too small to be
+#: seen in the viewer.
+LARGEST_BOX = 600
+
 #: Number of trial positions tried for a single atom by Metropolis
 #: placement before it gives up and raises ``ValueError``.
 PLACEMENT_ATTEMPTS = 1000
 
 
 def place_square(number_of_atoms: int, species: tuple[Species, ...], box: float) -> Configuration:
-    """Place atoms on a square lattice.
+    """Places atoms on a square lattice.
 
     The lattice has ``ceil(sqrt(number_of_atoms))`` sites along each side of
     the box, and the atoms fill those sites in order, taking the species in
-    turn. On a lattice with an even number of sites per side, a mixture
-    therefore starts out in stripes of one species and then the other.
-    Diffusion mixes them over the course of the run. No check is made for
-    overlapping atoms. A lattice packed too tightly for the potential
-    stores a large potential energy, and for a potential with a hard core that
-    energy is infinite.
+    turn. No check is made for overlapping atoms.
 
     Args:
         number_of_atoms: The number of atoms.
@@ -55,9 +58,7 @@ class _Lattice(NamedTuple):
         columns: The number of columns.
         rows: The number of rows.
         strain: How far the ratio of the row spacing to the column spacing
-            sits from :data:`TRIANGULAR_RATIO`, as a fraction of it. The six
-            neighbours of an atom split into two distances that differ by
-            about three quarters of the strain.
+            sits from :data:`TRIANGULAR_RATIO`, as a fraction of it.
     """
 
     columns: int
@@ -72,12 +73,10 @@ MOST_STRAIN = 1 / 3
 
 
 def _triangular_lattice(number_of_atoms: int) -> _Lattice | None:
-    """Return the columns, rows and strain of the best triangular lattice.
+    """Finds the columns, rows and strain of the best triangular lattice.
 
-    The lattice has ``columns * rows`` sites and an even number of rows. Its
-    strain is how far the ratio of its row spacing to its column spacing sits
-    from :data:`TRIANGULAR_RATIO`, as a fraction of that ratio, and the best
-    lattice is the one with the smallest strain. The return is ``None`` when
+    The lattice has ``columns * rows`` sites and an even number of rows, and
+    the best is the one with the smallest strain. The return is ``None`` when
     no even number of rows divides ``number_of_atoms``.
     """
     best: _Lattice | None = None
@@ -97,30 +96,19 @@ def place_triangular(
     box: float,
     max_strain: float = 0.05,
 ) -> Configuration:
-    """Place atoms on a triangular lattice that fills the box.
+    """Places atoms on a triangular lattice that fills the box.
 
-    A triangular lattice gives every atom six neighbours at one distance,
-    which is the arrangement a two-dimensional solid settles into. Fitting
-    one to a square box strains it a little, so the six split into two
-    distances differing by about three quarters of the strain. Each row is
-    offset along x by half a column spacing from the row below it, and there
-    is an even number of rows so that the offset keeps alternating across
-    the periodic boundary.
+    Each row is offset along x by half a column spacing from the row below
+    it, and the number of rows is even so that the offset keeps alternating
+    across the periodic boundary.
 
     The lattice fills the box, so the number of atoms has to be a number of
-    columns times an even number of rows. For the six to stay close to one
-    distance, the ratio of columns to rows has to be close to
-    ``sqrt(3) / 2``, and ``max_strain`` is the largest fraction of that
-    ratio a lattice may sit away from it, at most :data:`MOST_STRAIN`. At
-    the default the counts up to 300 that fit are 30, 56, 90, 120, 168, 224,
-    270 and 288.
+    columns times an even number of rows, with the ratio of columns to rows
+    within ``max_strain`` of ``sqrt(3) / 2``. At the default the counts up
+    to 300 that fit are 30, 56, 90, 120, 168, 224, 270 and 288.
 
-    The atoms fill the sites row by row, taking the species in turn. On a
-    lattice with an even number of columns, a mixture therefore starts out
-    in stripes of one species and then the other. Diffusion mixes them over
-    the course of the run. No check is made for overlapping atoms: a lattice
-    packed too tightly for the potential stores a large potential energy,
-    and for a potential with a hard core that energy is infinite.
+    The atoms fill the sites row by row, taking the species in turn. No
+    check is made for overlapping atoms.
 
     Args:
         number_of_atoms: The number of atoms.
@@ -167,11 +155,10 @@ SEARCH_RANGE = 300
 
 
 def _nearest_fitting(number_of_atoms: int, max_strain: float) -> list[int]:
-    """Return the nearest atom counts either side that do fill a lattice.
+    """Finds the nearest atom counts either side that do fill a lattice.
 
-    Counts that fit are close together, so stepping outward from
-    ``number_of_atoms`` finds them quickly. The list is empty when neither
-    direction has one within :data:`SEARCH_RANGE`.
+    The list is empty when neither direction has one within
+    :data:`SEARCH_RANGE`.
     """
     found = []
     for direction in (-1, 1):
@@ -190,7 +177,7 @@ def _nearest_fitting(number_of_atoms: int, max_strain: float) -> list[int]:
 def _no_lattice_message(
     number_of_atoms: int, best: _Lattice | None, max_strain: float
 ) -> str:
-    """Say that an atom count was refused and which counts would fit.
+    """Says that an atom count was refused and which counts would fit.
 
     Args:
         number_of_atoms: The number of atoms asked for.
@@ -225,26 +212,18 @@ def place_metropolis(
     placement_temperature: float,
     rng: np.random.Generator,
 ) -> Configuration:
-    """Place atoms one at a time by Metropolis insertion.
+    """Places atoms one at a time by Metropolis insertion.
 
     Each atom in turn is given a uniform trial position in the box,
     accepted by :func:`mc.accept` at ``placement_temperature`` on its
     interaction energy with the atoms already placed, and redrawn on
-    rejection. Before the atom is added it interacts with nothing, so its
-    interaction energy with the atoms already placed is exactly the energy
-    change the insertion causes.
-
-    Placing the atoms one after another gives a reasonable starting point,
-    not a configuration drawn from equilibrium. The atoms avoid the close
-    contacts the potential penalises at the placement temperature, and raising
-    that temperature makes closer contacts more likely. The run itself brings
-    the configuration to equilibrium.
+    rejection. The result is a reasonable starting point, not a
+    configuration drawn from equilibrium.
 
     Args:
         number_of_atoms: The number of atoms.
         box: The side length of the box, in metres.
-        model: The species, assigned to the atoms in turn, and the potential
-            between each pair of them.
+        model: The model.
         cut_off: The cut-off, in metres.
         placement_temperature: The temperature of the acceptance, in kelvin.
         rng: The generator to draw trial positions and acceptances from.
@@ -254,10 +233,8 @@ def place_metropolis(
 
     Raises:
         ValueError: If :data:`PLACEMENT_ATTEMPTS` trial positions are all
-            rejected for a single atom. At the highest densities this many
-            attempts can reach, success depends on the positions that happen to
-            be drawn, so the same call may succeed with one seed and raise with
-            another.
+            rejected for a single atom. Near the densest packing it can
+            reach, whether it succeeds depends on the seed.
     """
     # mc imports this module for place, so the acceptance criterion is
     # imported here rather than at the top of the module.
@@ -299,29 +276,31 @@ def place(
     cut_off: float | None,
     rng: np.random.Generator,
 ) -> tuple[Configuration, float]:
-    """Build the initial configuration for a simulation factory.
+    """Builds the initial configuration for a simulation.
 
-    Takes the box and cut-off in Angstrom, as the factories do, checks the
-    potentials at the cut-off before any placement is attempted, and places
-    the atoms.
+    Takes the box and cut-off in Angstrom, as
+    :meth:`~pylj.md.MDSimulation.initialise` and
+    :meth:`~pylj.mc.MCSimulation.initialise` do, checks the potentials at the
+    cut-off before any placement is attempted, and places the atoms.
 
     Args:
         number_of_atoms: The number of atoms.
         temperature: The temperature of the run, in kelvin.
-        box: The side length of the box, in Angstrom, from 4 to 600.
-        model: The species, assigned to the atoms in turn, and the potential
-            between each pair of them.
-        init_conf: ``'square'`` for a square lattice, ``'triangular'`` for a
-            triangular one, or ``'metropolis'`` for sequential Metropolis
-            insertion.
+        box: The side length of the box, in Angstrom, from
+            :data:`SMALLEST_BOX` to :data:`LARGEST_BOX`.
+        model: The model.
+        init_conf: How the atoms are placed. ``'square'`` puts them on a
+            square grid, ``'triangular'`` on a triangular lattice filling the
+            box, which constrains the number of atoms, and ``'metropolis'``
+            inserts them at random positions for a disordered start.
         placement_temperature: The temperature of the Metropolis acceptance
             used by ``'metropolis'``, in kelvin; ``None`` for the run
             temperature.
         max_strain: How far the fitted lattice may sit from
             ``sqrt(3) / 2``, as a fraction of that ratio, when ``'triangular'``
             fits its lattice to the box.
-        cut_off: The cut-off, in Angstrom; ``None`` for 15 Angstrom or half
-            the box, whichever is smaller.
+        cut_off: The cut-off, in Angstrom; ``None`` for
+            :data:`~pylj.simulation.DEFAULT_CUT_OFF` Angstrom or half the box, whichever is smaller.
         rng: The generator for Metropolis placement.
 
     Returns:
@@ -329,7 +308,8 @@ def place(
 
     Raises:
         ValueError: If no atoms are requested, a temperature is
-            not positive and finite, the box is outside 4 to 600 Angstrom,
+            not positive and finite, the box is outside
+            :data:`SMALLEST_BOX` to :data:`LARGEST_BOX` Angstrom,
             the cut-off exceeds half the box, a potential has not died away
             at the cut-off, ``init_conf`` is unknown, ``max_strain`` is not
             positive and finite or is above :data:`MOST_STRAIN`, no
@@ -342,11 +322,11 @@ def place(
     if placement_temperature is None:
         placement_temperature = temperature
     check_positive_finite("placement_temperature", placement_temperature)
-    if not 4 <= box <= 600:
+    if not SMALLEST_BOX <= box <= LARGEST_BOX:
         raise ValueError(
-            f"box must be between 4 and 600 Angstrom, not {box}: below 4 the cell cannot "
-            "hold more than one atom, and above 600 the atoms are too small to be "
-            "seen in the viewer."
+            f"box must be between {SMALLEST_BOX} and {LARGEST_BOX} Angstrom: below "
+            f"{SMALLEST_BOX} the cell cannot hold more than one atom, and above "
+            f"{LARGEST_BOX} the atoms are too small to be seen in the viewer."
         )
     box_m = box * 1e-10
     cut_off_m = _resolve_cut_off(box_m, None if cut_off is None else cut_off * 1e-10)
@@ -366,6 +346,6 @@ def place(
         )
     else:
         raise ValueError(
-            f"init_conf must be 'square', 'triangular' or 'metropolis', not {init_conf!r}"
+            "init_conf must be 'square', 'triangular' or 'metropolis'"
         )
     return configuration, cut_off_m

--- a/pylj/potentials.py
+++ b/pylj/potentials.py
@@ -1,5 +1,4 @@
-"""The atom species and the pair potentials that act between them:
-Lennard-Jones, Buckingham and the square well."""
+"""Atom species and pair potentials."""
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -10,7 +9,7 @@ from scipy.optimize import brentq
 
 
 def check_positive_finite(name: str, value: float) -> None:
-    """Raise ``ValueError`` unless ``value`` is positive and finite.
+    """Raises ``ValueError`` unless ``value`` is positive and finite.
 
     Args:
         name: The name of the parameter, for the error message.
@@ -42,11 +41,8 @@ class Species:
 class PairPotential(ABC):
     """The interface every pair potential implements.
 
-    A pair potential is a central potential: the energy of a pair of atoms,
-    and the force that follows from it, depend only on how far apart the two
-    atoms are, and not on the direction from one to the other. Both
-    ``energies`` and ``forces`` take an array of separations ``dr``, in metres,
-    and return an array of the same shape.
+    Both ``energies`` and ``forces`` take an array of separations ``dr``,
+    in metres, and return an array of the same shape.
 
     Attributes:
         min_separation: The separation, in metres, below which the potential
@@ -60,15 +56,14 @@ class PairPotential(ABC):
 
     @abstractmethod
     def energies(self, dr: ArrayLike) -> NDArray[np.float64]:
-        """Return the pair energy for each separation in ``dr``."""
+        """Evaluates the pair energy at each separation in ``dr``."""
 
     @abstractmethod
     def forces(self, dr: ArrayLike) -> NDArray[np.float64]:
-        """Return the signed radial force for each separation in ``dr``.
+        """Evaluates the signed radial force at each separation in ``dr``.
 
-        The value is minus the derivative of the energy with respect to the
-        separation, so it is positive where the interaction is repulsive and
-        negative where the interaction is attractive.
+        Minus the derivative of the energy with respect to the separation,
+        so positive where the interaction is repulsive.
         """
 
 
@@ -114,13 +109,9 @@ class Buckingham(PairPotential):
     .. math::
         E = A e^{-B r} - C / r^{6}
 
-    At short range the attractive term, minus C over r to the sixth, grows
-    faster than the exponential repulsion. The energy therefore rises to a
-    barrier as the atoms approach and then falls to minus infinity as
-    the separation goes to zero. That collapse is a defect of the formula,
-    not real physics. ``energies`` and ``forces`` return the formula at
-    every separation, and ``min_separation`` is set to the separation at the
-    top of the barrier, so a simulation never lets two atoms pass it.
+    The formula falls to minus infinity at short range, beyond a barrier.
+    ``energies`` and ``forces`` return it at every separation, and
+    ``min_separation`` is the separation at the top of that barrier.
 
     Args:
         a: The A parameter, an energy scale, in joules.
@@ -134,15 +125,14 @@ class Buckingham(PairPotential):
     Raises:
         ValueError: If ``a`` or ``b`` is not positive and finite, if ``c`` is
             negative or not finite, or if the barrier lies beyond 100
-            Angstrom, so that the formula collapses at every separation a
-            simulation could reach.
+            Angstrom.
     """
 
     def __init__(self, *, a: float, b: float, c: float):
         check_positive_finite("a", a)
         check_positive_finite("b", b)
         if not (np.isfinite(c) and c >= 0):
-            raise ValueError(f"c must be non-negative and finite, not {c}")
+            raise ValueError("c must be non-negative and finite")
         self.a = a
         self.b = b
         self.c = c
@@ -158,9 +148,7 @@ class Buckingham(PairPotential):
         return float(-self.a * self.b * np.exp(-self.b * dr) + 6 * self.c / dr**7)
 
     def _find_barrier(self) -> float:
-        """Locate the top of the short-range barrier. The slope of the energy is zero
-        there, between the fall to minus infinity at short range and the well
-        beyond."""
+        """Locates the top of the short-range barrier."""
         dr = np.geomspace(1e-13, 1e-8, 4000)
         with np.errstate(over="ignore"):
             barrier = int(np.argmax(self._form(dr)))
@@ -186,18 +174,11 @@ class Buckingham(PairPotential):
 
 
 class SquareWell(PairPotential):
-    r"""The square-well pair potential: a hard core surrounded by a well of
-    constant depth.
+    r"""The square-well pair potential.
 
-    The energy takes three values. When the separation is smaller than
-    ``sigma`` the atoms overlap and the energy is ``max_val``, infinite
-    by default. Between ``sigma`` and ``lambda_`` times ``sigma`` the
-    atoms sit in the well and the energy is minus ``epsilon``. Beyond
-    the well the energy is zero. Because the energy changes only in steps,
-    the force is zero everywhere except at the two walls, where it is
-    infinite. A potential without a finite force cannot drive molecular
-    dynamics, so the square well is for Monte Carlo, which uses energies
-    only.
+    The energy is ``max_val`` below ``sigma``, minus ``epsilon`` between
+    ``sigma`` and ``lambda_`` times ``sigma``, and zero beyond. It has no
+    finite force, so it is for Monte Carlo, which uses energies only.
 
     Args:
         epsilon: The well depth, in joules.
@@ -216,13 +197,12 @@ class SquareWell(PairPotential):
         check_positive_finite("sigma", sigma)
         if not (np.isfinite(lambda_) and lambda_ > 1):
             raise ValueError(
-                f"lambda_ must be greater than 1, not {lambda_}: the well lies outside "
-                "the hard core"
+                "lambda_ must be greater than 1: the well lies outside the hard core"
             )
         if not max_val > 0:
             raise ValueError(
-                f"max_val must be positive, not {max_val}: a hard core that lowers the "
-                "energy would draw atoms into it"
+                "max_val must be positive: a hard core that lowers the energy would "
+                "draw atoms into it"
             )
         self.epsilon = epsilon
         self.sigma = sigma

--- a/pylj/scattering.py
+++ b/pylj/scattering.py
@@ -1,5 +1,4 @@
-"""The structure factor of a configuration, evaluated at the wavevectors
-commensurate with its box."""
+"""Structure factor calculations."""
 
 import numpy as np
 from numpy.typing import NDArray
@@ -12,16 +11,10 @@ MOST_WAVEVECTORS = 1_000_000
 
 
 def default_q_max(number_of_atoms: int, box: float) -> float:
-    """Return a wavevector magnitude to draw a structure factor up to, in 1/m.
+    """Chooses the default largest wavevector magnitude, in 1/m.
 
-    A square box of side ``L`` holding ``N`` atoms leaves a mean spacing of
-    ``L / sqrt(N)`` between them. The wavevector matching that spacing,
-    ``2 pi sqrt(N) / L``, grows as the square root of the density, and the
-    magnitude returned is six times it.
-
-    How far a nearest neighbour sits is set by the potential rather than by
-    the density, so a dilute configuration is drawn up to a smaller multiple
-    of its first peak, where its S(q) is close to one throughout.
+    ``2 pi sqrt(N) / L`` matches the mean spacing between ``N`` atoms in a
+    box of side ``L``; the default is six times it.
 
     Args:
         number_of_atoms: The number of atoms.
@@ -34,12 +27,7 @@ def default_q_max(number_of_atoms: int, box: float) -> float:
 
 
 def check_q_max(q_max: float, box: float) -> None:
-    """Check that a wavevector magnitude is one the box has, and not too many.
-
-    The smallest wavevector a box of side ``L`` has is ``2 pi / L``, so a
-    ``q_max`` below that leaves nothing to evaluate. The number of
-    wavevectors grows as the square of ``q_max``, so it is bounded above by
-    :data:`MOST_WAVEVECTORS`.
+    """Checks a wavevector magnitude against the box and the wavevector limit.
 
     Args:
         q_max: The largest wavevector magnitude, in 1/m.
@@ -69,7 +57,7 @@ def check_q_max(q_max: float, box: float) -> None:
 def wavevectors(
     box: float, q_max: float
 ) -> tuple[NDArray[np.float64], NDArray[np.int64], NDArray[np.int64]]:
-    """Return the wavevectors commensurate with a box, grouped by magnitude.
+    """Enumerates the wavevectors commensurate with a box, grouped by magnitude.
 
     A square box of side ``L`` that repeats in both directions has the
     wavevectors ``2 pi (h, k) / L``, for integer ``h`` and ``k``. The pair
@@ -107,7 +95,7 @@ def wavevectors(
 def _phase_rows(
     coordinate: NDArray[np.float64], unit: float, limit: int
 ) -> NDArray[np.complex128]:
-    """Return ``exp(i unit h x)`` for every atom and every ``h``.
+    """Computes ``exp(i unit h x)`` for every atom and every ``h``.
 
     The rows run from ``-limit`` to ``limit``. Negative ``h`` gives the
     complex conjugate of positive ``h``, so only the non-negative rows are
@@ -131,18 +119,12 @@ def shell_average(
     index: NDArray[np.int64],
     shell: NDArray[np.int64],
 ) -> NDArray[np.float64]:
-    """Return the structure factor of a configuration, one value per shell.
+    """Computes the structure factor of a configuration.
 
-    The wavevector of a pair of integers ``(h, k)`` is ``2 pi (h, k) / L``,
-    and its amplitude is ``sum_j exp(i q . r_j)``, summed over the atom
-    positions ``r_j``. The structure factor at that wavevector is the square
-    of the modulus of the amplitude, divided by the number of atoms. Every
-    atom counts alike, whatever its species. The wavevectors that share a
-    magnitude are averaged together, so the result holds one value per shell.
-
-    A phase factor separates into one term per axis, ``exp(i q . r) =
-    exp(i q_x x) exp(i q_y y)``, so the amplitudes of every ``(h, k)`` are
-    the product of a matrix of phase factors along x with one along y.
+    The amplitude at a wavevector is ``sum_j exp(i q . r_j)`` over the atom
+    positions, and the structure factor is the square of its modulus divided
+    by the number of atoms. Every atom counts alike, whatever its species,
+    and the wavevectors of a shell are averaged together.
 
     Args:
         position: The atom positions, shape ``(N, 2)``, in metres.
@@ -153,6 +135,8 @@ def shell_average(
     Returns:
         The structure factor at each shell magnitude.
     """
+    # exp(i q . r) = exp(i q_x x) exp(i q_y y), so the amplitudes of every
+    # (h, k) are one matrix product of the per-axis phase factors.
     limit = int(np.abs(index).max())
     unit = 2 * np.pi / box
     along_x = _phase_rows(position[:, 0], unit, limit)

--- a/pylj/simulation.py
+++ b/pylj/simulation.py
@@ -1,5 +1,4 @@
-"""The checks a simulation makes on its model, the record it keeps of its
-samples, and the base class the simulations share."""
+"""Shared simulation base class and sample records."""
 
 import copy
 from abc import ABC, abstractmethod
@@ -15,6 +14,10 @@ from pylj.model import Model
 from pylj.potentials import check_positive_finite
 from pylj.trajectory import Trajectory
 
+#: The cut-off used when none is given, in Angstrom, or half the box if
+#: that is smaller.
+DEFAULT_CUT_OFF = 15
+
 #: Largest potential energy per atom, in units of k_B T, accepted for an
 #: initial configuration.
 INITIAL_ENERGY_LIMIT = 10.0
@@ -23,19 +26,16 @@ INITIAL_ENERGY_LIMIT = 10.0
 def _check_potentials_at_the_cut_off(
     model: Model, cut_off: float, temperature: float, box: float
 ) -> None:
-    """Check that every pair potential has died away at the cut-off.
+    """Checks that every pair potential has died away at the cut-off.
 
-    Truncating the interaction at the cut-off assumes it is negligible
-    there. The check is that each pair energy at the cut-off is finite and
-    within ``k_B T`` of zero.
+    The check is that each pair energy at the cut-off is finite and within
+    ``k_B T`` of zero.
 
     Args:
-        model: The species and the potential between each pair of them.
+        model: The model.
         cut_off: The cut-off, in metres.
         temperature: The temperature, in kelvin.
-        box: The side length of the box, in metres. The cut-off can be no
-            larger than half the box, so when it already is, the only remedy is
-            a larger box.
+        box: The side length of the box, in metres.
 
     Raises:
         ValueError: If any pair potential's energy at the cut-off is not
@@ -64,13 +64,11 @@ def _check_potentials_at_the_cut_off(
 
 
 def _check_initial_energy(energy: float, number_of_atoms: int, temperature: float) -> None:
-    """Refuse a starting configuration that stores far more potential energy
+    """Refuses a starting configuration that stores far more potential energy
     than thermal energy.
 
-    Potential energy stored in an initial configuration is released as
-    motion over the first steps and heats the run. A configuration holding
-    more than :data:`INITIAL_ENERGY_LIMIT` k_B T per atom has atoms
-    too close together for its temperature.
+    A configuration holding more than :data:`INITIAL_ENERGY_LIMIT` k_B T
+    per atom has atoms too close together for its temperature.
 
     Args:
         energy: The total pair energy of the configuration, in joules.
@@ -102,18 +100,17 @@ def _check_initial_energy(energy: float, number_of_atoms: int, temperature: floa
 
 
 def _resolve_cut_off(box: float, cut_off: float | None) -> float:
-    """Return the cut-off in metres.
+    """Resolves the cut-off to metres.
 
-    A cut-off given by the caller is used as it stands. Without one, the
-    cut-off is 15 Angstrom, or half the box if that is smaller.
+    A ``cut_off`` of ``None`` becomes :data:`DEFAULT_CUT_OFF` Angstrom, or
+    half the box if that is smaller.
 
     Raises:
-        ValueError: If a given cut-off is not positive and finite, or is larger
-            than half the box. A cut-off beyond half the box breaks the minimum
-            image convention.
+        ValueError: If a given cut-off is not positive and finite, or is
+            larger than half the box.
     """
     if cut_off is None:
-        return min(15e-10, box / 2)
+        return min(DEFAULT_CUT_OFF * 1e-10, box / 2)
     check_positive_finite("cut_off", cut_off)
     if cut_off > box / 2:
         raise ValueError(
@@ -132,10 +129,7 @@ def _empty() -> NDArray[np.float64]:
 class Samples:
     """The record a simulation's ``sample`` appends to.
 
-    Every array holds one entry per call of ``sample``, in order, so the
-    arrays line up: ``step[i]`` is the step at which the other arrays'
-    ``i``-th entries were measured. Subclasses add the quantities their
-    simulation measures.
+    Every array holds one entry per call of ``sample``, in order.
 
     Attributes:
         step: The step at which each sample was taken.
@@ -144,15 +138,14 @@ class Samples:
     step: NDArray[np.int64] = field(default_factory=lambda: np.array([], dtype=np.int64))
 
     def add(self, **values: float) -> None:
-        """Append one value to every array, keeping them aligned.
+        """Appends one value to every array.
 
         Args:
             **values: One value for each of this record's arrays, by name.
 
         Raises:
             ValueError: If the names do not match this record's arrays
-                exactly, since a missing or unknown name would leave the
-                arrays out of step.
+                exactly.
         """
         expected = {f.name for f in fields(self)}
         if set(values) != expected:
@@ -165,34 +158,27 @@ class Samples:
 
 
 class Simulation(ABC):
-    """A simulation: a configuration, the model, the numerical choices, and
-    the machinery that evolves the configuration and measures it.
+    """The base class molecular dynamics and Monte Carlo share.
 
-    ``MDSimulation`` and ``MCSimulation`` add ``step`` and ``sample`` to this
-    class. The constructor takes a configuration that has already been built,
-    in SI units. To start from a model and a number of atoms instead, use the
-    ``initialise`` method of one of those subclasses, which builds the
-    configuration for you.
+    The constructor takes a configuration that is already built, in SI
+    units; the ``initialise`` method of either subclass builds one from a
+    model and a number of atoms instead.
 
     Args:
         configuration: The starting configuration.
-        model: The species and the potential between each pair of them, a
-            :class:`~pylj.model.Model`.
-        cut_off: The separation, in metres, beyond which a pair's
-            interaction is taken as negligible. By default 15 Angstrom or
-            half the box, whichever is smaller; it may not exceed half the
-            box.
-        seed: Seed for the random number generator. The same seed
-            reproduces the same run; without one the run differs each time.
+        model: The model.
+        cut_off: The separation, in metres, beyond which a pair's energy
+            and force are zero. By default :data:`DEFAULT_CUT_OFF` Angstrom
+            or half the box,
+            whichever is smaller; it may not exceed half the box.
+        seed: Seed for the random number generator; the same seed
+            reproduces the run, and without one the run differs each time.
 
     Attributes:
         configuration: The current configuration.
-        model: The model.
-        cut_off: The cut-off, in metres.
         rng: The random number generator for this simulation.
         steps: The number of steps taken.
-        samples: The record ``sample`` appends to; subclasses replace it
-            with the record of what they measure.
+        samples: The record ``sample`` appends to.
         trajectory: The configurations sampled so far, a
             :class:`~pylj.trajectory.Trajectory`.
 
@@ -222,23 +208,19 @@ class Simulation(ABC):
 
     @abstractmethod
     def step(self) -> None:
-        """Advance the simulation by one step."""
+        """Advances the simulation by one step."""
 
     @abstractmethod
     def sample(self) -> None:
-        """Record the quantities of interest at the current step."""
+        """Records the current step in ``samples``."""
 
     def restart(self) -> Self:
-        """A new simulation that continues from the current configuration.
+        """Returns a new simulation continuing from the current configuration.
 
-        The new simulation shares the model, the numerical choices
-        and every other attribute with this one. Its random number generator
-        starts from a copy of this one's state, so what this simulation draws
-        next has no effect on the new one. The new simulation starts with
-        ``steps`` at zero, an empty record of samples and an empty trajectory.
-        A subclass that holds other per-run state extends this method to reset
-        it. This simulation is not changed. Use it to start a production run
-        after equilibration::
+        The new simulation copies the model, the numerical choices and the
+        state of the random number generator, and starts with ``steps`` at
+        zero, no samples and an empty trajectory. This simulation is
+        unchanged. Use it to start a production run after equilibration::
 
             for _ in range(1000):
                 simulation.step()

--- a/pylj/trajectory.py
+++ b/pylj/trajectory.py
@@ -1,5 +1,4 @@
-"""The configurations a simulation samples, kept in order for analysis
-after the run."""
+"""Sampled configurations, in order."""
 
 from collections.abc import Iterable, Iterator
 from typing import overload
@@ -15,11 +14,9 @@ class Trajectory:
     """The configurations a simulation has sampled, in order.
 
     A simulation appends its current configuration each time ``sample`` is
-    called, so a trajectory holds one frame per sample. Every frame comes
-    from the same system: the same box and the same number of atoms. A frame
-    is a :class:`~pylj.configuration.Configuration`, so ``trajectory[i]`` has
-    positions, a box and, for molecular dynamics, velocities. A slice such as
-    ``trajectory[100:]`` is a trajectory of the later frames.
+    called. Every frame has the same box and the same number of atoms.
+    Indexing gives a :class:`~pylj.configuration.Configuration`; slicing
+    gives a ``Trajectory``.
 
     Args:
         frames: Configurations to start with, in order.
@@ -31,7 +28,7 @@ class Trajectory:
             self.append(one)
 
     def append(self, configuration: Configuration) -> None:
-        """Add a frame to the end.
+        """Adds a frame to the end.
 
         Args:
             configuration: The frame to add.
@@ -87,10 +84,7 @@ class Trajectory:
     def rdf(
         self, bins: int = 100, r_max: float | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Return g(r) averaged over the frames.
-
-        Each frame's :meth:`~pylj.configuration.Configuration.rdf` is taken
-        and the mean over frames returned.
+        """Averages g(r) over the frames.
 
         Args:
             bins: The number of bins.
@@ -98,7 +92,7 @@ class Trajectory:
                 the box.
 
         Returns:
-            The centre of each bin, in metres, and the mean g(r) at each.
+            The bin centres, in metres, and the mean g(r) in each bin.
 
         Raises:
             ValueError: If the trajectory has no frames.
@@ -110,21 +104,19 @@ class Trajectory:
     def structure_factor(
         self, q_max: float | None = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Return the structure factor S(q) averaged over the frames.
+        """Averages the structure factor S(q) over the frames.
 
         The wavevectors come from the first frame, and every frame is
-        evaluated on that one set, so the mean is taken value by value.
-        S(q) of a frame is as
-        :meth:`~pylj.configuration.Configuration.structure_factor` defines
-        it.
+        evaluated on that one set.
 
         Args:
-            q_max: The largest wavevector magnitude, in 1/m. By default six
-                times ``2 pi sqrt(N) / L``, the wavevector that matches the
-                mean spacing between the ``N`` atoms of the first frame.
+            q_max: The largest wavevector magnitude, in 1/m; the default
+                comes from :func:`~pylj.scattering.default_q_max` for the
+                first frame.
 
         Returns:
-            The wavevector magnitudes, in 1/m, and the mean S(q) at each.
+            The wavevector magnitudes, in 1/m, and the mean S(q) at each
+            magnitude.
 
         Raises:
             ValueError: If the trajectory has no frames, or ``q_max`` is


### PR DESCRIPTION
The docstrings tried to document the code and teach the physics at the same
time, and did neither well. They now say what a caller needs: what the thing
is, what it takes and what it gives back. Nothing documented here has changed
meaning, and the physics the cut text carried is already in the narrative
documentation.

## What the pass applied

- Module docstrings are short noun phrases naming what the module holds,
  rather than a topic followed by an inventory of its contents.
- Classes and properties read as nouns, methods as descriptive third person.
  The package was previously split between imperative and descriptive forms.
- Each fact is stated once, on the thing it belongs to. Summaries no longer
  enumerate the `Args` or `Attributes` block beneath them, subclasses no
  longer restate their parents, and a constraint on one argument sits on that
  argument rather than in a free paragraph.
- Nothing documents what is already visible: a `frozen=True` decorator, a
  type annotation, a base class, or the behaviour of another function.
- Derivations, algorithm restatements and tuning advice are gone, along with
  several dangling references that had no antecedent.

## Code changes

Three thresholds were bare literals with their justification stranded in an
error message or absent entirely. They are now named constants carrying their
reasons, matching how `PLACEMENT_ATTEMPTS` and `MOST_STRAIN` are already
handled:

- `placement.SMALLEST_BOX` and `placement.LARGEST_BOX`, the 4 and 600 Angstrom
  bounds on the box.
- `simulation.DEFAULT_CUT_OFF`, the 15 Angstrom cut-off used when none is
  given, previously written out in five docstrings.

Five error messages no longer echo a value the caller has just passed in.
Messages that report a derived value, such as an array shape or a dtype, keep
it. `_resolve_cut_off` returns the same cut-off as before.
