### PR TITLE
Drop two arguments the library does not need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to pylj are recorded here. The format follows
 
 - The package is built from `pyproject.toml`; `setup.py`, `docker/` and `TODO.md` are removed. Releases publish to PyPI through trusted publishing from a GitHub release. The version lives in `pylj.__version__` only, and the runtime dependency on `jupyter` is now `ipython`, since only the viewers' redrawing needs a notebook.
 - The documentation is a set of pages on running a simulation, custom potentials and viewers, with the module reference, built with Sphinx and myst-nb (#85, #58).
-- A box length outside 4 to 600 Angstrom raises `ValueError` rather than `AttributeError`.
+- A box length below 4 Angstrom raises `ValueError` rather than `AttributeError`.
 - `md.heat_bath(configuration, bath_temperature)` returns the configuration with its velocities rescaled so that the instantaneous temperature is the bath temperature; it previously took the temperature sample array and rescaled towards its cumulative mean. A non-positive bath temperature, or a configuration at rest or with a non-finite temperature, raises `ValueError` (#76).
 - Python 3.11 or later is required. scipy is a dependency; Cython is not.
 - The initialisers compute the initial forces, so the first integration step uses real accelerations.

--- a/pylj/mc.py
+++ b/pylj/mc.py
@@ -53,7 +53,6 @@ def accept(
     energy_change: float,
     temperature: float,
     *,
-    random_number: float | None = None,
     rng: np.random.Generator | None = None,
 ) -> bool:
     """Applies the Metropolis criterion to an energy change.
@@ -62,8 +61,6 @@ def accept(
         energy_change: The change in energy under the proposed move, in
             joules.
         temperature: The temperature the acceptance is judged at, in kelvin.
-        random_number: The uniform random number the acceptance probability
-            is tested against. By default one is drawn from ``rng``.
         rng: The generator to draw from; pass the simulation's ``rng`` for
             a reproducible run. By default an unseeded generator is used.
 
@@ -72,11 +69,9 @@ def accept(
     """
     if energy_change <= 0:
         return True
-    if random_number is None:
-        if rng is None:
-            rng = np.random.default_rng()
-        random_number = rng.random()
-    return bool(random_number < np.exp(-energy_change / (BOLTZMANN * temperature)))
+    if rng is None:
+        rng = np.random.default_rng()
+    return bool(rng.random() < np.exp(-energy_change / (BOLTZMANN * temperature)))
 
 
 class MCSimulation(Simulation):
@@ -145,8 +140,8 @@ class MCSimulation(Simulation):
             model: The model.
             number_of_atoms: The number of atoms.
             temperature: The temperature of the simulation, in kelvin.
-            box: The side length of the box, in Angstrom, from
-                :data:`~pylj.placement.SMALLEST_BOX` to :data:`~pylj.placement.LARGEST_BOX`.
+            box: The side length of the box, in Angstrom, at least
+                :data:`~pylj.placement.SMALLEST_BOX`.
             init_conf: How the atoms are placed. ``'square'`` puts them on a
                 square grid, ``'triangular'`` on a triangular lattice filling
                 the box, which constrains the number of atoms, and

--- a/pylj/md.py
+++ b/pylj/md.py
@@ -143,8 +143,8 @@ class MDSimulation(Simulation):
             model: The model.
             number_of_atoms: The number of atoms, at least two.
             temperature: The initial temperature, in kelvin.
-            box: The side length of the box, in Angstrom, from
-                :data:`~pylj.placement.SMALLEST_BOX` to :data:`~pylj.placement.LARGEST_BOX`.
+            box: The side length of the box, in Angstrom, at least
+                :data:`~pylj.placement.SMALLEST_BOX`.
             init_conf: How the atoms are placed. ``'square'`` puts them on a
                 square grid, ``'triangular'`` on a triangular lattice filling
                 the box, which constrains the number of atoms, and

--- a/pylj/placement.py
+++ b/pylj/placement.py
@@ -14,10 +14,6 @@ from pylj.simulation import _check_potentials_at_the_cut_off, _resolve_cut_off
 #: than one atom.
 SMALLEST_BOX = 4
 
-#: The largest box, in Angstrom. Above this the atoms are too small to be
-#: seen in the viewer.
-LARGEST_BOX = 600
-
 #: Number of trial positions tried for a single atom by Metropolis
 #: placement before it gives up and raises ``ValueError``.
 PLACEMENT_ATTEMPTS = 1000
@@ -286,8 +282,8 @@ def place(
     Args:
         number_of_atoms: The number of atoms.
         temperature: The temperature of the run, in kelvin.
-        box: The side length of the box, in Angstrom, from
-            :data:`SMALLEST_BOX` to :data:`LARGEST_BOX`.
+        box: The side length of the box, in Angstrom, at least
+            :data:`SMALLEST_BOX`.
         model: The model.
         init_conf: How the atoms are placed. ``'square'`` puts them on a
             square grid, ``'triangular'`` on a triangular lattice filling the
@@ -308,8 +304,8 @@ def place(
 
     Raises:
         ValueError: If no atoms are requested, a temperature is
-            not positive and finite, the box is outside
-            :data:`SMALLEST_BOX` to :data:`LARGEST_BOX` Angstrom,
+            not positive and finite, the box is below
+            :data:`SMALLEST_BOX` Angstrom,
             the cut-off exceeds half the box, a potential has not died away
             at the cut-off, ``init_conf`` is unknown, ``max_strain`` is not
             positive and finite or is above :data:`MOST_STRAIN`, no
@@ -322,11 +318,10 @@ def place(
     if placement_temperature is None:
         placement_temperature = temperature
     check_positive_finite("placement_temperature", placement_temperature)
-    if not SMALLEST_BOX <= box <= LARGEST_BOX:
+    if box < SMALLEST_BOX:
         raise ValueError(
-            f"box must be between {SMALLEST_BOX} and {LARGEST_BOX} Angstrom: below "
-            f"{SMALLEST_BOX} the cell cannot hold more than one atom, and above "
-            f"{LARGEST_BOX} the atoms are too small to be seen in the viewer."
+            f"box must be at least {SMALLEST_BOX} Angstrom: below that the cell cannot "
+            "hold more than one atom."
         )
     box_m = box * 1e-10
     cut_off_m = _resolve_cut_off(box_m, None if cut_off is None else cut_off * 1e-10)

--- a/pylj/tests/test_mc.py
+++ b/pylj/tests/test_mc.py
@@ -24,11 +24,6 @@ class TestAccept(unittest.TestCase):
         self.assertTrue(mc.accept(0.0, 300, rng=rng))
         self.assertEqual(rng.random(), untouched.random())
 
-    def test_tests_an_uphill_change_against_the_random_number(self):
-        # A rise of 1e-20 J at 300 K has a Boltzmann factor of about 0.09.
-        self.assertTrue(mc.accept(1e-20, 300, random_number=0.01))
-        self.assertFalse(mc.accept(1e-20, 300, random_number=0.1))
-
     def test_draws_from_the_supplied_generator(self):
         # With n the generator's first draw, an uphill change whose
         # acceptance probability is (1 + n) / 2 is accepted and one whose

--- a/pylj/tests/test_placement.py
+++ b/pylj/tests/test_placement.py
@@ -166,10 +166,15 @@ class TestPlace(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "exceeds half the box"):
             place(2, 300, 40, cut_off=25)
 
-    def test_refuses_a_box_outside_the_viewer_range(self):
-        for box in (2, 1000):
-            with self.assertRaisesRegex(ValueError, "between 4 and 600 Angstrom"):
-                place(2, 300, box)
+    def test_refuses_a_box_too_small_to_hold_the_atoms(self):
+        with self.assertRaisesRegex(ValueError, "at least 4 Angstrom"):
+            place(2, 300, 2)
+
+    def test_accepts_a_box_too_large_to_draw(self):
+        # The viewer cannot usefully draw atoms this far apart, but nothing
+        # about the simulation stops it.
+        configuration, _ = place(2, 300, 1000)
+        self.assertAlmostEqual(configuration.box * 1e10, 1000)
 
     def test_refuses_an_unknown_init_conf(self):
         with self.assertRaisesRegex(ValueError, "'square', 'triangular' or 'metropolis'"):


### PR DESCRIPTION
Two arguments the library did not need.

## `random_number` on `mc.accept`

The parameter existed so that one test could pin the acceptance threshold
directly. Nothing in `MCSimulation` or `placement` ever passed it, so it was a
test seam sitting in the public interface of a teaching library.

`test_draws_from_the_supplied_generator` already pins the criterion in both
directions, and does it more tightly: it builds the energy changes from the
target acceptance probabilities rather than checking one rough Boltzmann
factor. Removing the parameter and its test leaves the criterion covered, and
mutating the comparison, the sign of the exponent, or the downhill shortcut
still fails the suite.

## The upper bound on the box

`place` refused a box above 600 Angstrom because the atoms become too small to
see. That is a limit of the viewer, not of the simulation: a run that never
opens a viewer has no reason to refuse a large cell, and the check made a
legitimate headless run impossible.

The lower bound stays and keeps its constant, `placement.SMALLEST_BOX`: a box
below 4 Angstrom cannot hold more than one atom, which is a property of the
cell rather than of how it is drawn. `placement.LARGEST_BOX` is gone, along
with the upper half of the message, and a test now pins that a 1000 Angstrom
box is accepted.
